### PR TITLE
typo fix | Thos to This

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3191,7 +3191,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				}
 				if($this->isCreative() and $this->server->limitedCreative) break;
 				$dropItem = $packet;
-				$item = $thos->inventory->contains($dropItem->item) ? $dropItem->item : $this->inventory->getItemInHand();
+				$item = $this->inventory->contains($dropItem->item) ? $dropItem->item : $this->inventory->getItemInHand();
 				$ev = new PlayerDropItemEvent($this, $item);
 				$this->server->getPluginManager()->callEvent($ev);
 				if($ev->isCancelled()){


### PR DESCRIPTION
Fixes: 

```

Notice: Undefined variable: thos in phar:///home/matthew/daemon/Genisys.phar/src/pocketmine/Player.php on line 3194

Notice: Trying to get property of non-object in phar:///home/matthew/daemon/Genisys.phar/src/pocketmine/Player.php on line 3194
```