### PR TITLE
Fixbug for FlintSteel

### DIFF
--- a/src/pocketmine/item/FlintSteel.php
+++ b/src/pocketmine/item/FlintSteel.php
@@ -78,6 +78,7 @@ class FlintSteel extends Tool{
 								$level->setBlock(new Vector3($px, $py, $tz), new Block(90, 0));
 							}
 						}
+						return true;
 					}
 				}
 			}
@@ -116,6 +117,7 @@ class FlintSteel extends Tool{
 								$level->setBlock(new Vector3($tx, $py, $pz), new Block(90, 0));
 							}
 						}
+						return true;
 					}
 				}
 			}


### PR DESCRIPTION
when FlintSteel create the Nether Portal successfully. It should not create the fire block at the same time.
就是打火石搞地狱门不会附带一个火焰了。成功创建门就直接return