### PR TITLE
Fixes a CommandSelector bug

### DIFF
--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -223,11 +223,6 @@ class SimpleCommandMap implements CommandMap{
 	}
 
 	private function dispatchAdvanced(CommandSender $sender, Command $command, $label, array $args, $offset = 0){
-		if(!$sender->isOp()){
-			$sender->sendMessage(TextFormat::RED . "You don't have permission to use Command Selector!");
-			$command->execute($sender, $label, $args);
-			return;
-		}
 		if(isset($args[$offset])){
 			$argsTemp = $args;
 			switch($args[$offset]){
@@ -267,6 +262,11 @@ class SimpleCommandMap implements CommandMap{
 					break;
 				default:
 					$this->dispatchAdvanced($sender, $command, $label, $argsTemp, $offset + 1);
+						if(!$sender->isOp()){
+							$sender->sendMessage(TextFormat::RED . "You don't have permission to use Command Selector!");
+							$command->execute($sender, $label, $args);
+								return;
+						}
 			}
 		}else $command->execute($sender, $label, $args);
 	}


### PR DESCRIPTION
When a non-op sends a command, it no longer sends the player a "You don't have permission to use Command Selector!" message.