### PR TITLE
Fix a bug

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2088,7 +2088,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					$this->addEffect(Effect::getEffect(Effect::HEALTH_BOOST)->setAmplifier(0)->setDuration(2 * 60 * 20));
 					$this->addEffect(Effect::getEffect(Effect::REGENERATION)->setAmplifier(1)->setDuration(5 * 20));
 				}elseif($slot->getId() == Item::POTION){
-					$this->inventory->addItem(new Item(Item::GLASS_BOTTLE, 0, 1));
+					$this->inventory->addItem(Item::get(Item::GLASS_BOTTLE, 0, 1));
 					switch($slot->getDamage()){
 						case Potion::NIGHT_VISION:
 							$this->addEffect(Effect::getEffect(Effect::NIGHT_VISION)->setAmplifier(0)->setDuration(3 * 60 * 20));


### PR DESCRIPTION
Fix a bug
 - Fix a bug that palyer cannot use the GlassBottle they get after drinking a potion.
 - 迷之bug 喝完不能马上使用 需要退出重进 或者 丢出去捡回来