### PR TITLE
*Workaround* (not fix) for broken tip messages in many plugins

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3905,7 +3905,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 * @return bool
 	 */
 	public function sendTip($message){
-		$ev = new PlayerTextPreSendEvent($this, $message, PlayerTextPreSendEvent::TIP);
+		/*$ev = new PlayerTextPreSendEvent($this, $message, PlayerTextPreSendEvent::TIP);
 		$this->server->getPluginManager()->callEvent($ev);
 		if(!$ev->isCancelled()){
 			$pk = new TextPacket();
@@ -3915,6 +3915,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			return true;
 		}
 		return false;
+		*/
+		return $this->sendPopup($message);
 	}
 
 	/**


### PR DESCRIPTION
Nothing fancy, simply redirects sendTip() to sendPopup(). Not ideal, but it works.
