### PR TITLE
store task handler

### DIFF
--- a/src/pocketmine/scheduler/TaskHandler.php
+++ b/src/pocketmine/scheduler/TaskHandler.php
@@ -62,6 +62,7 @@ class TaskHandler{
 		$this->period = $period;
 		$this->timingName = $timingName === null ? "Unknown" : $timingName;
 		$this->timings = Timings::getPluginTaskTimings($this, $period);
+		$this->task->setHandler($this);
 	}
 
 	/**


### PR DESCRIPTION
Pretty obvious. 
Looks like $taskHandler property was orphaned

Now we can do  $this->getHandler()->cancel(); from the task subclass 
I.e. PluginTask's inheritor could stop itself