### PR TITLE
Allow proper time continuum (time past 24000), fix monsters not burning outside of 0-24000 time

### DIFF
--- a/src/pocketmine/entity/Zombie.php
+++ b/src/pocketmine/entity/Zombie.php
@@ -128,8 +128,12 @@ class Zombie extends Monster{
 		$hasUpdate = parent::onUpdate($currentTick);
 
 		if($this->isAlive()){
-			$time = $this->getLevel()->getTime();
-			if(($time >= 0 and $time < 14000) or $time >= 23000) $this->setOnFire(2); //僵尸起火
+			/* Don't use time directly
+			 * Instead, get remainder of current time divided by 24,000
+			 * This tells us the time of day, which is what we really need
+			 */
+			$timeOfDay = abs($level->getTime() % 24000);
+			if(0 < $timeOfDay and $timeOfDay < 13000) $this->setOnFire(2); //僵尸起火
 			
 			$p = $this->getNearestPlayer();//找到最近的可以被仇恨的玩家
 			if(!$p) {

--- a/src/pocketmine/entity/ai/SkeletonAI.php
+++ b/src/pocketmine/entity/ai/SkeletonAI.php
@@ -582,7 +582,12 @@ class SkeletonAI{
 			foreach ($level->getEntities() as $zo){
 				if ($zo instanceof Skeleton) {
 					//var_dump($p->getLevel()->getTime());
-					if(0 < $level->getTime() and $level->getTime() < 13500){
+					/* Don't use time directly
+					 * Instead, get remainder of current time divided by 24,000
+					 * This tells us the time of day, which is what we really need
+					 */
+					$timeOfDay = abs($level->getTime() % 24000);
+					if(0 < $timeOfDay and $timeOfDay < 13000){
 						$v3 = new Vector3($zo->getX(), $zo->getY(), $zo->getZ());
 						$ok = true;
 						for ($y0 = $zo->getY() + 2; $y0 <= $zo->getY()+10; $y0++) {

--- a/src/pocketmine/entity/ai/ZombieAI.php
+++ b/src/pocketmine/entity/ai/ZombieAI.php
@@ -529,7 +529,12 @@ $xxx =0;$zzz=0;
 			foreach ($level->getEntities() as $zo){
 				if ($zo::NETWORK_ID == Zombie::NETWORK_ID) {
 					//var_dump($p->getLevel()->getTime());
-					if(0 < $level->getTime() and $level->getTime() < 13500){
+					/* Don't use time directly
+					 * Instead, get remainder of current time divided by 24,000
+					 * This tells us the time of day, which is what we really need
+					 */
+					$timeOfDay = abs($level->getTime() % 24000);
+					if(0 < $timeOfDay and $timeOfDay < 13000){
 						$v3 = new Vector3($zo->getX(), $zo->getY(), $zo->getZ());
 						$ok = true;
 						for ($y0 = $zo->getY() + 2; $y0 <= $zo->getY()+10; $y0++) {

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -727,9 +727,13 @@ class Level implements ChunkManager, Metadatable{
 			return;
 		}else{
 			$this->time += 1;
+			//The below code should not be necessary now that AIs for monsters which burn have been fixed
+			//Now can allow time to continue to day 2, day 3, day 4, etc.
+			/*
 			if($this->time > self::TIME_FULL){
 				$this->time = 0;
 			}
+			*/
 		}
 	}
 


### PR DESCRIPTION
Currently, time is reset to 0 whenever it goes past 24,000. I have enabled time past 24000 so that lunar cycles can progress properly.
I've also fixed issues where zombies and skeletons would not burn correctly when the time went past 24000