### PR TITLE
fix name for non-block items created by name

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -1247,6 +1247,7 @@ class Item{
 			$item = Item::fromString($id);
 			$id = $item->getId();
 			if($item->getDamage() != $meta) $meta = $item->getDamage();
+			$name = $item->getName();
 		}
 		$this->id = $id & 0xffff;
 		$this->meta = $meta !== null ? $meta & 0xffff : null;


### PR DESCRIPTION
Correcting bug  that If the item was created by name, than the name was set as 'Unknown'
