### PR TITLE
Fix the 'famous' getName() on null bug

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4072,7 +4072,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		parent::saveNBT();
 		if($this->level instanceof Level){
 			$this->namedtag->Level = new StringTag("Level", $this->level->getName());
-			if($this->spawnPosition instanceof Position and $this->spawnPosition->getLevel() instanceof Level){
+			if($this->spawnPosition instanceof Position and $this->spawnPosition->getLevel() instanceof Level and $this->spawnPosition->getLevel()->getProvider() !== NULL){
 				$this->namedtag["SpawnLevel"] = $this->spawnPosition->getLevel()->getName();
 				$this->namedtag["SpawnX"] = (int) $this->spawnPosition->x;
 				$this->namedtag["SpawnY"] = (int) $this->spawnPosition->y;


### PR DESCRIPTION
I don't even know why this is happening. But it seems to happen if a player's spawnposition is in a level wich was previously loaded, but then unloaded. (Then the next autosave gets called => save() gets a level wich is closed therefore the provider has been (probably even destructed) and becomes null wich triggers this getName() on null.)
** We should consider checking on all level get functions that are using the provider variable to check if the provider is not null (level not closed) for less plugin crashes) **

Here is a Traceback wich helped me:
```java
2016-05-29 [19:07:55] [Server thread/CRITICAL]: Error: "Call to a member function getName() on null" (EXCEPTION) in "/src/pocketmine/level/Level" at line 2995
2016-05-29 [19:07:55] [Server thread/DEBUG]: #0 /src/pocketmine/Player(3989): pocketmine\Player-&gt;save(boolean)
2016-05-29 [19:07:55] [Server thread/DEBUG]: #1 /src/pocketmine/Server(2473): pocketmine\Player-&gt;close(pocketmine\event\TranslationContainer ..e%multiplayer.player.left, string Server closed)
2016-05-29 [19:07:55] [Server thread/DEBUG]: #2 /src/pocketmine/Server(2670): pocketmine\Server-&gt;forceShutdown(boolean)
2016-05-29 [19:07:55] [Server thread/DEBUG]: #3 /src/pocketmine/Server(2611): pocketmine\Server-&gt;crashDump(boolean)
2016-05-29 [19:07:55] [Server thread/DEBUG]: #4 /src/pocketmine/Server(2078): pocketmine\Server-&gt;exceptionHandler(Error Error: Call to a member function getName() on null in phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/level/Level.php:2995.Stack trace:.#0 phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/Player.php(4076): pocketmine\level\Level-&gt;getName().#1 phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/Server.php(2829): pocketmine\Player-&gt;save(true).#2 phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/Server.php(3015): pocketmine\Server-&gt;doAutoSave().#3 phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/Server.php(2683): pocketmine\Server-&gt;tick().#4 phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/Server.php(2561): pocketmine\Server-&gt;tickProcessor().#5 phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/Server.php(2076): pocketmine\Server-&gt;start().#6 phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/PocketMine.php(467): pocketmine\Server-&gt;__construct(Object(pocketmine\CompatibleClassLoader), Object(pocketmine\utils\MainLogger), 'phar:///home/pm...', '/home/pm1/', '/home/pm1/plugi...', 'unknown').#7 /home/pm1/PocketMine-MP.phar(1): require_once('phar:///home/pm...').#8 {main})
2016-05-29 [19:07:55] [Server thread/DEBUG]: #5 /src/pocketmine/PocketMine(467): pocketmine\Server-&gt;__construct(pocketmine\CompatibleClassLoader object, pocketmine\utils\MainLogger object, string phar:///home/pm1/PocketMine-MP.phar/, string /home/pm1/, string /home/pm1/plugins/, string unknown)
2016-05-29 [19:07:55] [Server thread/DEBUG]: #6 (1): require_once(string phar:///home/pm1/PocketMine-MP.phar/src/pocketmine/PocketMine.php)
2016-05-29 [19:07:55] [Server thread/EMERGENCY]: Crashed while crashing, killing process
```