### PR TITLE
Reduced the movement change check value to 0.01

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1723,7 +1723,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					//if($this->server->redstoneEnabled) $this->getLevel()->updateAround($ev->getTo()->round());
 
 					//	if(!$teleported){
-					if($to->distanceSquared($ev->getTo()) > 0.2){ //If plugins modify the destination
+					if($to->distanceSquared($ev->getTo()) > 0.01){ //If plugins modify the destination
 						$this->teleport($ev->getTo());
 					}else{
 						$this->level->addEntityMovement($this->x >> 4, $this->z >> 4, $this->getId(), $this->x, $this->y + $this->getEyeHeight(), $this->z, $this->yaw, $this->pitch, $this->yaw);


### PR DESCRIPTION
Fixed an issue that happens to me. Look at this:

``
$to = clone $event->getFrom();
$to->yaw = $event->getTo()->yaw;
$to->pitch = $event->getTo()->pitch;
$event->setTo($to);
``
This is supposed to allow the player turn their heads when they can't move, but because of this > 0.2
They can move very slowly, which is not a good thing.

More proof here: https://github.com/PocketMine/PocketMine-MP/blob/master/src/pocketmine/Player.php#L1413

Thanks!