### PR TITLE
Surpass time_sleep_until error when server has lag

### DIFF
--- a/src/raklib/server/SessionManager.php
+++ b/src/raklib/server/SessionManager.php
@@ -106,7 +106,7 @@ class SessionManager{
 			while($this->receiveStream());
 			$time = microtime(true) - $start;
 			if($time < 0.05){
-				time_sleep_until(microtime(true) + 0.05 - $time);
+				@time_sleep_until(microtime(true) + 0.05 - $time);
 			}
 			$this->tick();
 		}


### PR DESCRIPTION
A lot of people experience this error if their server is lagging severely:
```
 An E_WARNING error happened: "time_sleep_until(): Sleep until to time is less than current time" in "/src/raklib/server/SessionManager" at line 109
```
I believe this surpasses the warning/error.