### PR TITLE
Fixed the age-old hotbar glitch when changing slots rapidly

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2661,6 +2661,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						for($i = 0; $i < $this->inventory->getHotbarSize(); ++$i){
 							if($this->inventory->getHotbarSlotIndex($i) === -1){
 								$this->inventory->setHeldItemIndex($i);
+								$this->inventory->sendHeldItem($this->getViewers());
 								$found = true;
 								break;
 							}
@@ -2695,8 +2696,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						break;
 					}
 				}
-
-				$this->inventory->sendHeldItem($this->hasSpawned);
 
 				$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_ACTION, false);
 				break;

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -78,12 +78,13 @@ class PlayerInventory extends BaseInventory{
 	public function setHeldItemIndex($index){
 		if($index >= 0 and $index < $this->getHotbarSize()){
 			$this->itemInHandIndex = $index;
-
+			/*
 			if($this->getHolder() instanceof Player){
 				$this->sendHeldItem($this->getHolder());
 			}
 
 			$this->sendHeldItem($this->getHolder()->getViewers());
+			*/
 		}
 	}
 
@@ -124,6 +125,7 @@ class PlayerInventory extends BaseInventory{
 			}
 
 			$this->setHotbarSlotIndex($itemIndex, $slot);
+			$this->sendHeldItem($this->getHolder()->getViewers());
 		}
 	}
 


### PR DESCRIPTION
There is no need to send packets back to the client when they change hotbar slots. The server was returning several `MobEquipmentPacket`s to the client which were causing unnecessary hotbar slot changes.

I have tested this patch heavily before committing and it works perfectly to the best of my knowledge.