### PR TITLE
Reverted array_filter function on args

### DIFF
--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -44,7 +44,6 @@ class TeleportCommand extends VanillaCommand{
 			return true;
 		}
 
-		$args = array_filter($args);
 		if(count($args) < 1 or count($args) > 6){
 			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 


### PR DESCRIPTION
Removed the array_filter call on args as it prevents players from teleporting to coordinates that contain zeros