### PR TITLE
0.15 critical bug fixes - fixes most problems on the checklist in #1180

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -139,6 +139,7 @@ use pocketmine\network\protocol\PlayStatusPacket;
 use pocketmine\network\protocol\RespawnPacket;
 use pocketmine\network\protocol\SetDifficultyPacket;
 use pocketmine\network\protocol\SetEntityMotionPacket;
+use pocketmine\network\protocol\SetEntityDataPacket;
 use pocketmine\network\protocol\SetHealthPacket;
 use pocketmine\network\protocol\SetSpawnPositionPacket;
 use pocketmine\network\protocol\SetTimePacket;
@@ -2452,6 +2453,12 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$pk->slots = array_merge(Item::getCreativeItems(), $this->personalCreativeItems);
 			$this->dataPacket($pk);
 		}
+		
+		$pk = new SetEntityDataPacket();
+		$pk->eid = 0;
+		$pk->metadata = [self::DATA_LEAD_HOLDER => [self::DATA_TYPE_LONG, -1]];
+		$this->dataPacket($pk);
+		
 		$this->forceMovement = $this->teleportPosition = $this->getPosition();
 	}
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -80,7 +80,7 @@ abstract class Entity extends Location implements Metadatable{
 	const DATA_TYPE_STRING = 4;
 	const DATA_TYPE_SLOT = 5;
 	const DATA_TYPE_POS = 6;
-	//const DATA_TYPE_ROTATION = 7;
+	//const DATA_TYPE_ROTATION = 8;
 	//const DATA_TYPE_LONG = 8;
 	const DATA_TYPE_LONG = 7;
 	

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -80,9 +80,10 @@ abstract class Entity extends Location implements Metadatable{
 	const DATA_TYPE_STRING = 4;
 	const DATA_TYPE_SLOT = 5;
 	const DATA_TYPE_POS = 6;
-	const DATA_TYPE_ROTATION = 7;
-	const DATA_TYPE_LONG = 8;
-
+	//const DATA_TYPE_ROTATION = 7;
+	//const DATA_TYPE_LONG = 8;
+	const DATA_TYPE_LONG = 7;
+	
 	const DATA_FLAGS = 0;
 	const DATA_AIR = 1;
 	const DATA_NAMETAG = 2;
@@ -91,6 +92,9 @@ abstract class Entity extends Location implements Metadatable{
 	const DATA_POTION_COLOR = 7;
 	const DATA_POTION_AMBIENT = 8;
 	const DATA_NO_AI = 15;
+
+	const DATA_LEAD_HOLDER = 23;
+	const DATA_LEAD = 24;
 
 
 	const DATA_FLAG_ONFIRE = 0;
@@ -124,6 +128,8 @@ abstract class Entity extends Location implements Metadatable{
 		self::DATA_SHOW_NAMETAG => [self::DATA_TYPE_BYTE, 1],
 		self::DATA_SILENT => [self::DATA_TYPE_BYTE, 0],
 		self::DATA_NO_AI => [self::DATA_TYPE_BYTE, 0],
+		self::DATA_LEAD_HOLDER => [self::DATA_TYPE_LONG, -1],
+		self::DATA_LEAD => [self::DATA_TYPE_BYTE, 0],
 	];
 
 	public $passenger = null;

--- a/src/pocketmine/network/protocol/AddEntityPacket.php
+++ b/src/pocketmine/network/protocol/AddEntityPacket.php
@@ -58,10 +58,17 @@ class AddEntityPacket extends DataPacket{
 		$this->putFloat($this->speedX);
 		$this->putFloat($this->speedY);
 		$this->putFloat($this->speedZ);
-		$this->putFloat($this->yaw);
-		$this->putFloat($this->pitch);
-		$meta = Binary::writeMetadata($this->metadata);
-		$this->put($meta);
+		//$this->putFloat($this->yaw);
+		//$this->putFloat($this->pitch);
+		//$meta = Binary::writeMetadata($this->metadata);
+		//$this->put($meta);
+		$this->putFloat($this->yaw * 0.71111);
+		$this->putFloat($this->pitch * 0.71111);
+		$this->putShort(0);
+		if(!empty($this->metadata)) {
+			$meta = Binary::writeMetadata($this->metadata);
+			$this->put($meta);
+		}
 		$this->putShort(count($this->links));
 		foreach($this->links as $link){
 			$this->putLong($link[0]);

--- a/src/pocketmine/network/protocol/AddEntityPacket.php
+++ b/src/pocketmine/network/protocol/AddEntityPacket.php
@@ -41,7 +41,7 @@ class AddEntityPacket extends DataPacket{
 	public $speedZ;
 	public $yaw;
 	public $pitch;
-	public $metadata;
+	public $metadata = [];
 	public $links = [];
 
 	public function decode(){
@@ -69,12 +69,13 @@ class AddEntityPacket extends DataPacket{
 			$meta = Binary::writeMetadata($this->metadata);
 			$this->put($meta);
 		}
-		$this->putShort(count($this->links));
+		$this->putShort(0);
+		/*$this->putShort(count($this->links));
 		foreach($this->links as $link){
 			$this->putLong($link[0]);
 			$this->putLong($link[1]);
 			$this->putByte($link[2]);
-		}
+		}*/
 	}
 
 }

--- a/src/pocketmine/network/protocol/MoveEntityPacket.php
+++ b/src/pocketmine/network/protocol/MoveEntityPacket.php
@@ -43,15 +43,15 @@ class MoveEntityPacket extends DataPacket{
 
 	public function encode(){
 		$this->reset();
-		$this->putInt(count($this->entities));
+		//$this->putInt(count($this->entities));
 		foreach($this->entities as $d){
 			$this->putLong($d[0]); //eid
 			$this->putFloat($d[1]); //x
 			$this->putFloat($d[2]); //y
 			$this->putFloat($d[3]); //z
-			$this->putFloat($d[4]); //yaw
-			$this->putFloat($d[5]); //headYaw
-			$this->putFloat($d[6]); //pitch
+			$this->putByte($d[6] * 0.71111); //yaw
+			$this->putByte($d[5] * 0.71111); //headYaw
+			$this->putByte($d[4] * 0.71111); //pitch
 		}
 	}
 

--- a/src/pocketmine/network/protocol/SetEntityMotionPacket.php
+++ b/src/pocketmine/network/protocol/SetEntityMotionPacket.php
@@ -43,7 +43,7 @@ class SetEntityMotionPacket extends DataPacket{
 
 	public function encode(){
 		$this->reset();
-		$this->putInt(count($this->entities));
+		//$this->putInt(count($this->entities));
 		foreach($this->entities as $d){
 			$this->putLong($d[0]); //eid
 			$this->putFloat($d[1]); //motX

--- a/src/pocketmine/network/protocol/UpdateBlockPacket.php
+++ b/src/pocketmine/network/protocol/UpdateBlockPacket.php
@@ -44,7 +44,7 @@ class UpdateBlockPacket extends DataPacket{
 
 	public function encode(){
 		$this->reset();
-		$this->putInt(count($this->records));
+		//$this->putInt(count($this->records));
 		foreach($this->records as $r){
 			$this->putInt($r[0]);
 			$this->putInt($r[1]);


### PR DESCRIPTION
I've just spent the last two hours sifting through the code changes made in #1185, which was an absolute nightmare. Turns out most of the code was copy-pasted from Steadfast2 and was completely unnecessary. I've finally trimmed it down to the useful bits and fixed most of the issues on the checklist on #1180 .

Fixes:
- Mob spawns will no longer crash the game (thanks @Muqsit )
- Players are no longer tethered to all other mobs/players (thanks again to @Muqsit )
    
**EDIT**: Leash issues are _partially_ fixed.
- Mobs now move again (without walking round backwards!) (credits to Steadfast2 by way of @XFuryMCPE )
- Block updates work again (credits to me)