### PR TITLE
Rewritten /banlist command. Fixed some translations

### DIFF
--- a/src/pocketmine/command/defaults/BanListCommand.php
+++ b/src/pocketmine/command/defaults/BanListCommand.php
@@ -39,39 +39,39 @@ class BanListCommand extends VanillaCommand{
 
 	public function execute(CommandSender $sender, $currentAlias, array $args){
 		if(!$this->testPermission($sender)){
-			return \true;
+			return true;
 		}
-		$list = $sender->getServer()->getNameBans();
-		if(isset($args[0])){
-			$args[0] = \strtolower($args[0]);
-			if($args[0] === "ips"){
-				$list = $sender->getServer()->getIPBans();
-			}elseif($args[0] === "players"){
+		
+		$args[0] = (isset($args[0]) ? strtolower($args[0]): "");
+		$title = "";
+		
+		switch($args[0]){
+			case "ips":
+				$list = $sender->getServer()->getIPBans();	
+				$title = "commands.banlist.ips";
+				break;
+			case "cids":
+				$list = $list = $sender->getServer()->getCIDBans(); 
+				$title = "commands.banlist.cids";
+				break;
+			case "players":
 				$list = $sender->getServer()->getNameBans();
-			}elseif($args[0] === "cids") {
-				$list = $sender->getServer()->getCIDBans();
-			}else{
+				$title = "commands.banlist.players";
+				break;
+			default:
 				$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
-
-				return \false;
-			}
+				return false;			
 		}
-
+		
 		$message = "";
 		$list = $list->getEntries();
 		foreach($list as $entry){
 			$message .= $entry->getName() . ", ";
 		}
 		
-		if(!isset($args[0])) return \false;
-		if($args[0] === "ips"){
-			$sender->sendMessage(Server::getInstance()->getLanguage()->translateString("commands.banlist.ips", [\count($list)]));
-		}elseif($args[0] === "players"){
-			$sender->sendMessage(Server::getInstance()->getLanguage()->translateString("commands.banlist.players", [\count($list)]));
-		}else $sender->sendMessage("共有 ".\count($list)."被ban");
-
+		$sender->sendMessage(Server::getInstance()->getLanguage()->translateString($title, [count($list)]));
 		$sender->sendMessage(\substr($message, 0, -2));
 
-		return \true;
+		return true;
 	}
 }

--- a/src/pocketmine/command/defaults/BiomeCommand.php
+++ b/src/pocketmine/command/defaults/BiomeCommand.php
@@ -52,12 +52,12 @@ class BiomeCommand extends VanillaCommand{
 				$biome = isset($args[1]) ? $args[1] : 1;//默认改成草原
 				if(isset($sender->selectedPos[0]) and isset($sender->selectedPos[1])){
 					if(is_numeric($biome) === false){
-						$sender->sendMessage(TextFormat::RED . "%pocketmine.command.biome.wrongBio");
+						$sender->sendMessage(TextFormat::RED . new TranslationContainer("pocketmine.command.biome.wrongBio"));
 						return false;
 					}
 					$biome = (int) $biome;
 					if($sender->selectedLev[0] !== $sender->selectedLev[1]){
-						$sender->sendMessage(TextFormat::RED . "%pocketmine.command.biome.wrongLev");
+						$sender->sendMessage(TextFormat::RED . new TranslationContainer("pocketmine.command.biome.wrongLev"));
 						return false;
 					}
 					$x1 = min($sender->selectedPos[0][0], $sender->selectedPos[1][0]);
@@ -72,19 +72,19 @@ class BiomeCommand extends VanillaCommand{
 					}
 					$sender->sendMessage(new TranslationContainer("pocketmine.command.biome.set", [$biome]));
 				}else{
-					$sender->sendMessage("%pocketmine.command.biome.noPos");
+					$sender->sendMessage(new TranslationContainer("pocketmine.command.biome.noPos"));
 				}
 			}elseif($args[0] == "color"){
 				$color = isset($args[1]) ? $args[1] : "146,188,89";//1=草原("146,188,89"),2=沙漠(251,183,19)"130,180,147"
 				$a = explode(",", $color);
 				//var_dump($a);
 				if(count($a) != 3){
-					$sender->sendMessage(TextFormat::RED . "%pocketmine.command.biome.wrongCol");
+					$sender->sendMessage(TextFormat::RED . new TranslationContainer("pocketmine.command.biome.wrongCol"));
 					return false;
 				}
 				if(isset($sender->selectedPos[0]) and isset($sender->selectedPos[1])){
 					if($sender->selectedLev[0] !== $sender->selectedLev[1]){
-						$sender->sendMessage(TextFormat::RED . "%pocketmine.command.biome.wrongLev");
+						$sender->sendMessage(TextFormat::RED . new TranslationContainer("pocketmine.command.biome.wrongLev"));
 						return false;
 					}
 					$x1 = min($sender->selectedPos[0][0], $sender->selectedPos[1][0]);
@@ -100,7 +100,7 @@ class BiomeCommand extends VanillaCommand{
 					//$sender->selectedPos = array();
 					$sender->sendMessage(new TranslationContainer("pocketmine.command.biome.color", [$a[0], $a[1], $a[2]]));
 				}else{
-					$sender->sendMessage("%pocketmine.command.biome.noPos");
+					$sender->sendMessage(new TranslationContainer("pocketmine.command.biome.noPos"));
 				}
 			}elseif($args[0] == "pos1"){
 				$x = floor($sender->getX());
@@ -127,7 +127,7 @@ class BiomeCommand extends VanillaCommand{
 				return true;
 			}
 		}else{
-			$sender->sendMessage("%commands.generic.runingame");
+			$sender->sendMessage(new TranslationContainer("commands.generic.runingame"));
 			return false;
 		}
 	}

--- a/src/pocketmine/command/defaults/PardonCidCommand.php
+++ b/src/pocketmine/command/defaults/PardonCidCommand.php
@@ -19,19 +19,18 @@ class PardonCidCommand extends VanillaCommand{
 
 	public function execute(CommandSender $sender, $currentAlias, array $args){
 		if(!$this->testPermission($sender)){
-			return \true;
+			return true;
 		}
 
-		if(\count($args) !== 1){
+		if(count($args) !== 1){
 			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
-
-			return \false;
+			return false;
 		}
 
 		$sender->getServer()->getCIDBans()->remove($args[0]);
 
-		Command::broadcastCommandMessage($sender, new TranslationContainer("commands.unban.success", [$args[0]]));
+		Command::broadcastCommandMessage($sender, new TranslationContainer("commands.unbancid.success", [$args[0]]));
 
-		return \true;
+		return true;
 	}
 }

--- a/src/pocketmine/lang/locale/chs.ini
+++ b/src/pocketmine/lang/locale/chs.ini
@@ -113,7 +113,7 @@ commands.players.list=There are {%0}/{%1} players online:
 commands.kill.successful=已删除 {%0}
 commands.banlist.ips=共有 {%0} 个被封锁的 IP 地址：
 commands.banlist.players=共有 {%0} 个被封锁的玩家：
-commands.banlist.usage=/banlist [ips|players]
+commands.banlist.usage=/banlist [ips|players|cids]
 commands.defaultgamemode.usage=/defaultgamemode <模式>
 commands.defaultgamemode.success=服务器的默认游戏模式为 {%0}
 

--- a/src/pocketmine/lang/locale/eng.ini
+++ b/src/pocketmine/lang/locale/eng.ini
@@ -111,9 +111,10 @@ commands.particle.notFound=Unknown effect name {%0}
 commands.players.usage=/list
 commands.players.list=There are {%0}/{%1} players online:
 commands.kill.successful=Killed {%0}
-commands.banlist.ips=There are %d total banned IP addresses:
+commands.banlist.ips=There are {%0} total banned IP addresses:
 commands.banlist.players=There are {%0} total banned players:
-commands.banlist.usage=/banlist [ips|players]
+commands.banlist.cids=There are {%0} total banned CIDs:
+commands.banlist.usage=/banlist [ips|players|cids]
 commands.defaultgamemode.usage=/defaultgamemode <mode>
 commands.defaultgamemode.success=The world's default game mode is now {%0}
 
@@ -131,10 +132,11 @@ commands.seed.success=Seed: {%0}
 commands.bancidbyname.success=Banned player {%0}'s CID
 commands.bancidbyname.usage=/bancidbyname <player>
 
-commands.bancid.success=BAN CID: {%0}
+commands.bancid.success=Banned CID {%0}
 commands.bancid.usage=/bancid <ClientID>
 
 commands.unbancid.usage=/pardoncid <ClientID>
+commands.unbancid.success=Unbanned CID {%0}
 
 commands.ban.success=Banned player {%0}
 commands.ban.usage=/ban <name> [reason ...] [time(day)]
@@ -292,15 +294,15 @@ pocketmine.command.gc.tiles=Tiles:
 pocketmine.command.gc.cycles=Cycles:
 pocketmine.command.gc.memory=Release memory:
 
-pocketmine.command.biome.description=change the biome of the area.(To change snow or rain)
-pocketmine.command.biome.posset=Has set pos{%3} at:({%1},{%2})[{%0}]
-pocketmine.command.biome.get=The ID of biome you stay is {%0} Color:{%1},{%2},{%3}
-pocketmine.command.biome.wrongLev=Cannot set point in different level.
+pocketmine.command.biome.description=Change the biome of the area.(To change snow or rain)
+pocketmine.command.biome.posset=Set position {%3} at ({%1},{%2}) in level {%0}
+pocketmine.command.biome.get=The ID of biome you are in is {%0}. Color: {%1},{%2},{%3}
+pocketmine.command.biome.wrongLev=Cannot set position in different level.
 pocketmine.command.biome.wrongBio=Wrong ID of biome. e.g. 1 (Plains), 2 (Desert)，13 (Ice Mountains)，6 (Swampland)
 pocketmine.command.biome.wrongCol=Wrong Color. e.g. 146,188,89 .Use "/biome get" to get other color.
-pocketmine.command.biome.noPos=Plz use "/biome pos1|pos2" to select the area first.
-pocketmine.command.biome.set=Has set biome as：{%0}
-pocketmine.command.biome.color=Has set color as：{%0},{%1},{%2}
+pocketmine.command.biome.noPos=Please use "/biome pos1|pos2" to select the area first.
+pocketmine.command.biome.set=Set the selected area's biome to {%0}
+pocketmine.command.biome.color=Set the grass colour to {%0},{%1},{%2}
 
 pocketmine.command.timings.description=Records timings to see performance of the server.
 pocketmine.command.timings.usage=/timings <reset|report|on|off|paste>
@@ -323,7 +325,7 @@ pocketmine.command.particle.description=Adds particles to a world
 pocketmine.command.particle.usage=/particle <name> <x> <y> <z> <xd> <yd> <zd> [count] [data]
 pocketmine.command.time.description=Changes the time on each world
 pocketmine.command.time.usage=/time <set|add> <value> OR /time <start|stop|query>
-pocketmine.command.bancidbyname.description=Prevents the specified CID by name from using this server禁止指定玩家的設備 ID
+pocketmine.command.bancidbyname.description=Prevents the specified CID by name from using this server
 pocketmine.command.bancid.description=Prevents the specified CID from using this server
 pocketmine.command.banipbyname.description=Prevents the specified IP address by name from using this server
 pocketmine.command.ban.player.description=Prevents the specified player from using this server


### PR DESCRIPTION
The `/banlist` command has irritated me for ages because it didn't work properly, so I've rewritten it and it is now fully working. I've also fixed several bad translations and translation errors.

Fixes:
- Typing `/banlist` with no parameters will now show a usage message instead of doing nothing whatsoever
- `/banlist` usage message now includes `cids` as a possible parameter
- Title for `/banlist ips` will now show an actual number instead of `%d`
- `/biome` command translation improvements and fixes.
- Removed lots of unnecessary `\`s which were causing unexpected behaviour.