### PR TITLE
Protection emchantment for armors.

### DIFF
--- a/src/pocketmine/block/Fire.php
+++ b/src/pocketmine/block/Fire.php
@@ -68,14 +68,16 @@ class Fire extends Flowable{
 	}
 
 	public function onEntityCollide(Entity $entity){
+		$ProtectL = 0;
 		if(!$entity->hasEffect(Effect::FIRE_RESISTANCE)){
 			$ev = new EntityDamageByBlockEvent($this, $entity, EntityDamageEvent::CAUSE_FIRE, 1);
 			if($entity->attack($ev->getFinalDamage(), $ev) === true){
 				$ev->useArmors();
 			}
+			$ProtectL = $ev->getMaxEnchantLevel();
 		}
 
-		$ev = new EntityCombustByBlockEvent($this, $entity, 8);
+		$ev = new EntityCombustByBlockEvent($this, $entity, 8, $ProtectL);
 		if($entity instanceof Arrow){
 			$ev->setCancelled();
 		}

--- a/src/pocketmine/block/Lava.php
+++ b/src/pocketmine/block/Lava.php
@@ -48,14 +48,16 @@ class Lava extends Liquid{
 
 	public function onEntityCollide(Entity $entity){
 		$entity->fallDistance *= 0.5;
+		$ProtectL = 0;
 		if(!$entity->hasEffect(Effect::FIRE_RESISTANCE)){
 			$ev = new EntityDamageByBlockEvent($this, $entity, EntityDamageEvent::CAUSE_LAVA, 4);
 			if($entity->attack($ev->getFinalDamage(), $ev) === true){
 				$ev->useArmors();
 			}
+			$ProtectL = $ev->getMaxEnchantLevel();
 		}
 
-		$ev = new EntityCombustByBlockEvent($this, $entity, 15);
+		$ev = new EntityCombustByBlockEvent($this, $entity, 15, $ProtectL);
 		Server::getInstance()->getPluginManager()->callEvent($ev);
 		if(!$ev->isCancelled()){
 			$entity->setOnFire($ev->getDuration());

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -656,7 +656,7 @@ abstract class Entity extends Location implements Metadatable{
 		}
 		$this->setLastDamageCause($source);
 
-		$this->setHealth($this->getHealth() - $source->getFinalDamage());
+		$this->setHealth($this->getHealth() - round($source->getFinalDamage()));
 		return true;
 	}
 

--- a/src/pocketmine/event/entity/EntityCombustByBlockEvent.php
+++ b/src/pocketmine/event/entity/EntityCombustByBlockEvent.php
@@ -32,9 +32,10 @@ class EntityCombustByBlockEvent extends EntityCombustEvent{
 	 * @param Block  $combuster
 	 * @param Entity $combustee
 	 * @param int    $duration
+	 * @param int    $ProtectLevel
 	 */
-	public function __construct(Block $combuster, Entity $combustee, $duration){
-		parent::__construct($combustee, $duration);
+	public function __construct(Block $combuster, Entity $combustee, $duration, $ProtectLevel = 0){
+		parent::__construct($combustee, $duration, $ProtectLevel);
 		$this->combuster = $combuster;
 	}
 

--- a/src/pocketmine/event/entity/EntityCombustByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityCombustByEntityEvent.php
@@ -31,9 +31,10 @@ class EntityCombustByEntityEvent extends EntityCombustEvent{
 	 * @param Entity $combuster
 	 * @param Entity $combustee
 	 * @param int    $duration
+	 * @param int    $ProtectLevel
 	 */
-	public function __construct(Entity $combuster, Entity $combustee, $duration){
-		parent::__construct($combustee, $duration);
+	public function __construct(Entity $combuster, Entity $combustee, $duration, $ProtectLevel = 0){
+		parent::__construct($combustee, $duration, $ProtectLevel);
 		$this->combuster = $combuster;
 	}
 

--- a/src/pocketmine/event/entity/EntityCombustEvent.php
+++ b/src/pocketmine/event/entity/EntityCombustEvent.php
@@ -28,22 +28,32 @@ class EntityCombustEvent extends EntityEvent implements Cancellable{
 	public static $handlerList = null;
 
 	protected $duration;
+	protected $ProtectLevel;
 
 	/**
 	 * @param Entity $combustee
 	 * @param int    $duration
+	 * @param int    $ProtectLevel
 	 */
-	public function __construct(Entity $combustee, $duration){
+	public function __construct(Entity $combustee, $duration, $ProtectLevel = 0){
 		$this->entity = $combustee;
 		$this->duration = $duration;
+		$this->ProtectLevel = $ProtectLevel;
 	}
 
 	public function getDuration(){
-		return $this->duration;
+		if($this->ProtectLevel !== 0){
+			return round($this->duration * (1 - 0.15 * $this->ProtectLevel));
+		}else{
+			return $this->duration;
+		}
 	}
 
 	public function setDuration($duration){
 		$this->duration = (int) $duration;
 	}
 
+	public function setProtectLevel($ProtectLevel){
+		$this->ProtectLevel = (int) $ProtectLevel;
+	}
 }

--- a/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
@@ -47,7 +47,7 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 
 	protected function addAttackerModifiers(Entity $damager){
 		if($damager->hasEffect(Effect::STRENGTH)){
-			$this->setDamage(1 + 0.3 * ($damager->getEffect(Effect::STRENGTH)->getAmplifier() + 1), self::MODIFIER_STRENGTH);
+			$this->setRateDamage(1 + 0.3 * ($damager->getEffect(Effect::STRENGTH)->getAmplifier() + 1), self::MODIFIER_STRENGTH);
 		}
 
 		if($damager->hasEffect(Effect::WEAKNESS)){
@@ -55,7 +55,7 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 			if($eff_level < 0){
 				$eff_level = 0;
 			}
-			$this->setDamage($eff_level, self::MODIFIER_WEAKNESS);
+			$this->setRateDamage($eff_level, self::MODIFIER_WEAKNESS);
 		}
 	}
 

--- a/src/pocketmine/event/entity/EntityDamageEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageEvent.php
@@ -26,6 +26,7 @@ use pocketmine\entity\Entity;
 use pocketmine\event\Cancellable;
 use pocketmine\Player;
 use pocketmine\item\Item;
+use pocketmine\item\enchantment\enchantment;
 
 class EntityDamageEvent extends EntityEvent implements Cancellable{
 	public static $handlerList = null;
@@ -61,8 +62,10 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	private $cause;
 	/** @var array */
 	private $modifiers;
+	private $ratemodifiers = [];
 	private $originals;
 	private $use_armors = [];
+	private $EPF = 0;
 
 
 	/**
@@ -96,21 +99,21 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 				if($RES_level < 0){
 					$RES_level = 0;
 				}
-				$this->setDamage($RES_level, self::MODIFIER_RESISTANCE);
+				$this->setRateDamage($RES_level, self::MODIFIER_RESISTANCE);
 			}
 		}
 
-		//For MODIFIER_ARMOR
-		switch($cause){
-			case self::CAUSE_CONTACT:
-			case self::CAUSE_ENTITY_ATTACK:
-			case self::CAUSE_PROJECTILE:
-			case self::CAUSE_FIRE:
-			case self::CAUSE_LAVA:
-			case self::CAUSE_BLOCK_EXPLOSION:
-			case self::CAUSE_ENTITY_EXPLOSION:
-			case self::CAUSE_LIGHTNING:
-				if($entity instanceof Player){
+		//TODO: add zombie
+		if($entity instanceof Player){
+			switch($cause){
+				case self::CAUSE_CONTACT:
+				case self::CAUSE_ENTITY_ATTACK:
+				case self::CAUSE_PROJECTILE:
+				case self::CAUSE_FIRE:
+				case self::CAUSE_LAVA:
+				case self::CAUSE_BLOCK_EXPLOSION:
+				case self::CAUSE_ENTITY_EXPLOSION:
+				case self::CAUSE_LIGHTNING:
 					$points = 0;
 					foreach($entity->getInventory()->getArmorContents() as  $i){
 						if($i->isArmor()){
@@ -118,25 +121,48 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 						}
 					}
 					if($points !== 0){
-						$this->setDamage(1 - 0.04 * $points, self::MODIFIER_ARMOR);
+						$this->setRateDamage(1 - 0.04 * $points, self::MODIFIER_ARMOR);
 						$this->use_armors = $entity->getInventory()->getArmorContents();
 					}
-				}
-				break;
-			case self::CAUSE_FALL:
-				break;
-			case self::CAUSE_FIRE_TICK:
-				break;
-			case self::CAUSE_SUFFOCATION:
-			case self::CAUSE_DROWNING:
-			case self::CAUSE_VOID:
-			case self::CAUSE_SUICIDE:
-			case self::CAUSE_MAGIC:
-			case self::CAUSE_CUSTOM:
-			case self::CAUSE_STARVATION:
-				break;
-			default:
-				break;
+					//For Protection
+					switch ($cause){
+						case self::CAUSE_ENTITY_EXPLOSION:
+						case self::CAUSE_BLOCK_EXPLOSION:
+							break;
+						case self::CAUSE_FIRE:
+						case self::CAUSE_LAVA:
+							break;
+						case self::CAUSE_PROJECTILE:
+							break;
+						default;
+							break;
+					}
+					foreach($this->use_armors as  $i){
+						if($i->isArmor()){
+							$this->EPF += $i->getEnchantmentLevel(Enchantment::TYPE_ARMOR_PROTECTION);
+						}
+					}
+					if($this->EPF !== 0){
+						$this->EPF = min(20, ceil($this->EPF * mt_rand(50, 100) / 100));
+						$this->setRateDamage(1 - 0.04 * $this->EPF, self::MODIFIER_PROTECTION);
+					}
+					break;
+				case self::CAUSE_FALL:
+					//Feather Falling
+
+					break;
+				case self::CAUSE_FIRE_TICK:
+				case self::CAUSE_SUFFOCATION:
+				case self::CAUSE_DROWNING:
+				case self::CAUSE_VOID:
+				case self::CAUSE_SUICIDE:
+				case self::CAUSE_MAGIC:
+				case self::CAUSE_CUSTOM:
+				case self::CAUSE_STARVATION:
+					break;
+				default:
+					break;
+			}
 		}
 
 		//For MODIFIER_PROTECTION TODO: add all kind of PROTECTION Enchantment
@@ -158,7 +184,6 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 		if(isset($this->originals[$type])){
 			return $this->originals[$type];
 		}
-
 		return 0;
 	}
 
@@ -188,6 +213,30 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	/**
 	 * @param int $type
 	 *
+	 * @return float
+	 */
+	public function getRateDamage($type = self::MODIFIER_BASE){
+		if(isset($this->ratemodifiers[$type])){
+			return $this->ratemodifiers[$type];
+		}
+		return 0;
+	}
+
+	/**
+	 * @param float $damage
+	 * @param int   $type
+	 *
+	 * Notice:If you want to add/reduce the damage without reducing by Armor or effect. set a new Damage using setDamage
+	 * Notice:If you want to add/reduce the damage within reducing by Armor of effect. Plz change the MODIFIER_BASE
+	 * Notice:If you want to add/reduce the damage by multiplying. Plz use this function.
+	 */
+	public function setRateDamage($damage, $type = self::MODIFIER_BASE){
+		$this->ratemodifiers[$type] = $damage;
+	}
+
+	/**
+	 * @param int $type
+	 *
 	 * @return bool
 	 */
 	public function isApplicable($type){
@@ -198,9 +247,14 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	 * @return int
 	 */
 	public function getFinalDamage(){
-		$damage = 1;
-		foreach($this->modifiers as $type => $d){
+		$damage = $this->modifiers[self::MODIFIER_BASE];
+		foreach($this->ratemodifiers as $type => $d){
 			$damage *= $d;
+		}
+		foreach($this->modifiers as $type => $d){
+			if($type !== self::MODIFIER_BASE){
+				$damage += $d;
+			}
 		}
 		return $damage;
 	}


### PR DESCRIPTION
Emmmmm...It's me again. This time i bring some works for your CPU too. :(
Protection Enchantment for armor
 - Protection
 - Fire Protection now is available.(Also reduces burn time)
 - Feather Falling.(Do not lost your armors' durability)
 - A part of Blast Protection.(cannot reduces explosion knockback now.)
 - Projectile Protection.

make some other change for old plugins.
 - Notice:If you want to add/reduce the damage without reducing by Armor or effect. set a new Damage using setDamage
 - Notice:If you want to add/reduce the damage within reducing by Armor of effect. Plz change the MODIFIER_BASE
 - Notice:If you want to add/reduce the damage by multiplying. Plz use setRateDamage.