### PR TITLE
Removed useless code inside the FallingSand class.

### DIFF
--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -106,6 +106,12 @@ class FallingSand extends Entity{
 		if($this->isAlive()){
 			$pos = (new Vector3($this->x - 0.5, $this->y, $this->z - 0.5))->round();
 
+			if($this->ticksLived === 1){
+				if($block->getId() !== $this->blockId){
+					return true;
+				}
+				$this->level->setBlock($pos, Block::get(0), true);
+			}
 			$this->motionY -= $this->gravity;
 
 			$this->move($this->motionX, $this->motionY, $this->motionZ);

--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -106,15 +106,6 @@ class FallingSand extends Entity{
 		if($this->isAlive()){
 			$pos = (new Vector3($this->x - 0.5, $this->y, $this->z - 0.5))->round();
 
-			if($this->ticksLived === 1){
-				$block = $this->level->getBlock($pos);
-				if($block->getId() !== $this->blockId){
-					$this->kill();
-					return true;
-				}
-				$this->level->setBlock($pos, Block::get(0), true);
-			}
-
 			$this->motionY -= $this->gravity;
 
 			$this->move($this->motionX, $this->motionY, $this->motionZ);

--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -105,7 +105,8 @@ class FallingSand extends Entity{
 
 		if($this->isAlive()){
 			$pos = (new Vector3($this->x - 0.5, $this->y, $this->z - 0.5))->round();
-
+			$block = $this->level->getBlock($pos);
+			
 			if($this->ticksLived === 1){
 				if($block->getId() !== $this->blockId){
 					return true;


### PR DESCRIPTION
I don't get the point of that code. I made a plugin that spawned a FallingSand entity, and the entity was killed immediately after spawn if it was spawned mid-air. The issue was fixed after I removed this piece of code.