### PR TITLE
Removed redundant code inside the FallingSand class

### DIFF
--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -109,7 +109,6 @@ class FallingSand extends Entity{
 			if($this->ticksLived === 1){
 				$block = $this->level->getBlock($pos);
 				if($block->getId() !== $this->blockId){
-					$this->kill();
 					return true;
 				}
 				$this->level->setBlock($pos, Block::get(0), true);


### PR DESCRIPTION
I don't get the point of that code. I made a plugin that spawned a FallingSand entity, and the entity was killed immediately after spawn if it was spawned mid-air. The issue was fixed after I removed this line of code.