### PR TITLE
XP autoname

### DIFF
--- a/src/pocketmine/command/defaults/XpCommand.php
+++ b/src/pocketmine/command/defaults/XpCommand.php
@@ -47,8 +47,9 @@ class XpCommand extends VanillaCommand{
 			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 			return false;
 		}else{
-			$player = $sender->getServer()->getPlayerExact($name = $args[1]);
+			$player = $sender->getServer()->getPlayer($args[1]);
 			if($player instanceof Player){
+				$name = $player->getName();
 				if(strcasecmp(substr($args[0], -1), "L") == 0){			//Set Experience Level(with "L" after args[0])
 					$level = rtrim($args[0], "Ll");
 					if(is_numeric($level)){


### PR DESCRIPTION
This allows players to not have to put the whole name for the XP command. Sorry about the other pull requests, I apologize.