### PR TITLE
Fixed entity rotation issues

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -839,9 +839,17 @@ class Level implements ChunkManager, Metadatable{
 
 		foreach($this->moveToSend as $index => $entry){
 			Level::getXZ($index, $chunkX, $chunkZ);
-			$pk = new MoveEntityPacket();
-			$pk->entities = $entry;
-			$this->addChunkPacket($chunkX, $chunkZ, $pk);
+			foreach($entry as $e) {
+				$pk = new MoveEntityPacket();
+				$pk->eid = $e[0];
+				$pk->x = $e[1];
+				$pk->y = $e[2];
+				$pk->z = $e[3];
+				$pk->yaw = $e[4];
+				$pk->headYaw = $e[5];
+				$pk->pitch = $e[6];
+				$this->addChunkPacket($chunkX, $chunkZ, $pk);
+			}
 		}
 		$this->moveToSend = [];
 

--- a/src/pocketmine/network/protocol/MoveEntityPacket.php
+++ b/src/pocketmine/network/protocol/MoveEntityPacket.php
@@ -26,33 +26,33 @@ namespace pocketmine\network\protocol;
 
 class MoveEntityPacket extends DataPacket{
 	const NETWORK_ID = Info::MOVE_ENTITY_PACKET;
-
-
-	// eid, x, y, z, yaw, pitch
-	/** @var array[] */
-	public $entities = [];
-
-	public function clean(){
-		$this->entities = [];
-		return parent::clean();
-	}
-
+	
+	public $eid;
+	public $x;
+	public $y;
+	public $z;
+	public $yaw;
+	public $headYaw;
+	public $pitch;
+	
 	public function decode(){
-
+		$this->eid = $this->getLong();
+		$this->x = $this->getFloat();
+		$this->y = $this->getFloat();
+		$this->z = $this->getFloat();
+		$this->pitch = $this->getByte()*(360.0/256);
+		$this->yaw = $this->getByte()*(360.0/256);
+		$this->headYaw = $this->getByte()*(360.0/256);
 	}
-
+	
 	public function encode(){
 		$this->reset();
-		//$this->putInt(count($this->entities));
-		foreach($this->entities as $d){
-			$this->putLong($d[0]); //eid
-			$this->putFloat($d[1]); //x
-			$this->putFloat($d[2]); //y
-			$this->putFloat($d[3]); //z
-			$this->putByte($d[6] * 0.71111); //yaw
-			$this->putByte($d[5] * 0.71111); //headYaw
-			$this->putByte($d[4] * 0.71111); //pitch
-		}
+		$this->putLong($this->eid);
+		$this->putFloat($this->x);
+		$this->putFloat($this->y);
+		$this->putFloat($this->z);
+		$this->putByte($this->pitch/(360.0/256));
+		$this->putByte($this->yaw/(360.0/256));
+		$this->putByte($this->headYaw/(360.0/256));
 	}
-
 }


### PR DESCRIPTION
Tested this and it works. Fixes entity rotation issues with plugins and
maybe mobs from spawn eggs. Copied from PocketMine, written by intyre