### PR TITLE
Throw an exception for invalid or empty batch packets. Close #1448

### DIFF
--- a/src/pocketmine/network/Network.php
+++ b/src/pocketmine/network/Network.php
@@ -224,6 +224,10 @@ class Network {
 				$buf = substr($str, $offset, $pkLen);
 				$offset += $pkLen;
 
+				if(strlen($buf) === 0){
+					throw new \InvalidStateException("Empty or invalid BatchPacket received");
+				}
+				
 				if (($pk = $this->getPacket(ord($buf{0}))) !== null) {
 					if ($pk::NETWORK_ID === Info::BATCH_PACKET) {
 						throw new \InvalidStateException("Invalid BatchPacket inside BatchPacket");


### PR DESCRIPTION
### Description
Should fix #1448 . I haven't been able to test this, please test and feedback.


### Reason to modify
- Fix never-ending loop of terminal spam.
- I don't think this will resolve the actual problem, which is that we are decoding a batch packet incorrectly. However, I think this should prove effective until that can be fixed.

### Tests & Reviews
Please review things below:
- I cannot reproduce this issue myself so I can't test this code. It will fall to someone who _can_ reproduce it to test this.