### PR TITLE
fix fence gate turning on activate

### DIFF
--- a/src/pocketmine/block/FenceGate.php
+++ b/src/pocketmine/block/FenceGate.php
@@ -110,8 +110,6 @@ class FenceGate extends Transparent implements ElectricalAppliance{
 			2 => 1,
 			3 => 2,
 		];
-		if($player !== null) $this->meta = ($faces[$player instanceof Player ? $player->getDirection() : 0] & 0x03) | ((~$this->meta) & 0x04);
-		else $this->meta ^= 0x04;
 		$this->getLevel()->setBlock($this, $this, true);
 		$this->level->addSound(new DoorSound($this));
 		return true;


### PR DESCRIPTION
### Description
Fixes the fence gate turning to face the player every time it activates


### Reason to modify
Because the fence gate is not behaving correctly. It does behave correctly after this change.


### Tests & Reviews
I have tested this, and the fence gates no longer turn to face the player on activate, just on placement, as it should. Interestingly, the fence gate still always opens away from the player, which is also a good thing. It just doesn't turn if the player is facing the gate's side.

