### PR TITLE
Fix #1456

### DIFF
--- a/src/pocketmine/block/GlowingObsidian.php
+++ b/src/pocketmine/block/GlowingObsidian.php
@@ -22,7 +22,7 @@
 namespace pocketmine\block;
 
 
-class GlowingObsidian extends Solid{
+class GlowingObsidian extends Flowable{
 
 	protected $id = self::GLOWING_OBSIDIAN;
 


### PR DESCRIPTION
### Description
Fix Glowing obsidian lighting

### Reason to modify
Fix #1456 


### Tests & Reviews
I have tested the code and it works. Left and rejoined server before change, glowing obsidian light wasn't updated and was left dark, now it lights up whenever teleported to it.


