### PR TITLE
Change default format to anvil

### DIFF
--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -92,7 +92,7 @@ debug:
 
 level-settings:
  #The default format that levels will use when created
- default-format: mcregion
+ default-format: anvil
  #If true, converts from a format that is not the default to the default format on load
  #NOTE: This is currently not implemented
  convert-format: false


### PR DESCRIPTION
### Description
Change genisys' default level format


### Reason to modify
MCRegion is not supported by some tools, such as MCEdit, and requires conversion for use in MCPC (MCPC is supposed to convert it automatically, but I've found that converting Genisys-created worlds is non-trivial, and requires a few steps).


### Tests & Reviews
Nothing to test really. Just a defaults change.

I'm proposing that we change the default format for new levels to Anvil, a superior format to MCRegion for a number of reasons, as well as the default format on PC, which will make things a lot easier to move back and forth, without conversion. I just find it's a far more sensible default format...