### PR TITLE
add invisible bedrock

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -304,6 +304,7 @@ class Block extends Position implements BlockIds, Metadatable{
 			self::$list[self::POWERED_REPEATER_BLOCK] = PoweredRepeater::class;
 			self::$list[self::UNPOWERED_REPEATER_BLOCK] = UnpoweredRepeater::class;
 			self::$list[self::CAULDRON_BLOCK] = Cauldron::class;
+			self::$list[self::INVISIBLE_BEDROCK] = InvisibleBedrock::class;
 
 			foreach(self::$list as $id => $class){
 				if($class !== null){

--- a/src/pocketmine/block/InvisibleBedrock.php
+++ b/src/pocketmine/block/InvisibleBedrock.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____  
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \ 
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/ 
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_| 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ * 
+ *
+*/
+
+namespace pocketmine\block;
+
+use pocketmine\item\Item;
+
+class InvisibleBedrock extends Transparent{
+
+	protected $id = self::INVISIBLE_BEDROCK;
+
+	public function __construct(){
+
+	}
+
+	public function getName() : string{
+		return "Invisible Bedrock";
+	}
+
+	public function getHardness() {
+		return -1;
+	}
+
+	public function getResistance(){
+		return 18000000;
+	}
+
+	public function isBreakable(Item $item){
+		return false;
+	}
+
+}


### PR DESCRIPTION
### Description
Adds invisible bedrock support, to act as a barrier. Very useful in certain situations. Don't add this to creative items, because it's a sort of dangerous block. Hard to remove without manually removing it via console or plugin.


### Reason to modify
Because invisible bedrock doesn't work at the moment


### Tests & Reviews
I am now able to /give myself invisible bedrock, and place it. Removal is a problem, so this should only be obtainable through /give.