### PR TITLE
Fix crash MCPE on incorrect block

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -27,6 +27,7 @@ namespace pocketmine\level;
 use pocketmine\block\Air;
 use pocketmine\block\Beetroot;
 use pocketmine\block\Block;
+use pocketmine\block\BlockIds;
 use pocketmine\block\BrownMushroom;
 use pocketmine\block\Cactus;
 use pocketmine\block\Carrot;
@@ -938,10 +939,10 @@ class Level implements ChunkManager, Metadatable{
 				}
 
 				if($b instanceof Block){
-					$batchPacketList[$top]->records[] = [$b->x, $b->z, $b->y, $b->getId(), $b->getDamage(), $first ? $flags : UpdateBlockPacket::FLAG_NONE];
+					$batchPacketList[$top]->records[] = [$b->x, $b->z, $b->y, (in_array($b->getId(), new ReflectionClass(BlockIds::class)->getConstants()) ? $b->getId() : 248), $b->getDamage(), $first ? $flags : UpdateBlockPacket::FLAG_NONE];
 				}else{
 					$fullBlock = $this->getFullBlock($b->x, $b->y, $b->z);
-					$batchPacketList[$top]->records[] = [$b->x, $b->z, $b->y, $fullBlock >> 4, $fullBlock & 0xf, $first ? $flags : UpdateBlockPacket::FLAG_NONE];
+					$batchPacketList[$top]->records[] = [$b->x, $b->z, $b->y, (in_array($fullBlock >> 4, new ReflectionClass(BlockIds::class)->getConstants()) ? $fullBlock >> 4 : 248), $fullBlock & 0xf, $first ? $flags : UpdateBlockPacket::FLAG_NONE];
 				}
 			}
 		}else{


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Fix crashes of MCPE client, on receive unknown block(bug in 0.15).

### Reason to modify
<!-- Think twice before modifying: is it the best way? will it break things? 
Have you made sure that there is actually a problem before trying to fix it? -->
I trying to fix crash on unknown blocks. There is PC maps, yeah!

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->

<!-- Please review things below: -->
There is no visual effect, only replaces unknown blocks to UPDATE block, like in Singleplayer. 
