### PR TITLE
Fix GroundCover error on world generation

### DIFF
--- a/src/pocketmine/level/generator/populator/GroundCover.php
+++ b/src/pocketmine/level/generator/populator/GroundCover.php
@@ -32,7 +32,7 @@ class GroundCover extends Populator{
 
 	public function populate(ChunkManager $level, $chunkX, $chunkZ, Random $random){
 		$chunk = $level->getChunk($chunkX, $chunkZ);
-		if($level instanceof Level or $level instanceof SimpleChunkManager){
+		if($level instanceof Level){
 			$waterHeight = $level->getWaterHeight();
 		} else {
 			$waterHeight = 0;


### PR DESCRIPTION
### Description
Fixes errors on startup with world generation


### Reason to modify
Tested by removing all configuration and restarting with this change, problem is no longer present


### Tests & Reviews
Tested the code and it works.

Fixes: `[Asynchronous Worker #4 thread/CRITICAL]: Error: "Call to undefined method pocketmine\level\SimpleChunkManager::getWaterHeight()" (EXCEPTION) in "/src/pocketmine/level/generator/populator/GroundCover" at line 36`