### PR TITLE
Big weather improvements and cleanup. Fixed #1472

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2293,6 +2293,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$pk->metadata = [self::DATA_LEAD_HOLDER => [self::DATA_TYPE_LONG, -1]];
 		$this->dataPacket($pk);
 		
+		$this->level->getWeather()->sendWeather($this);
+		
 		$this->forceMovement = $this->teleportPosition = $this->getPosition();
 	}
 

--- a/src/pocketmine/command/defaults/WeatherCommand.php
+++ b/src/pocketmine/command/defaults/WeatherCommand.php
@@ -73,7 +73,7 @@ class WeatherCommand extends VanillaCommand{
 		}
 
 		if(count($args) < 2){
-			$sender->sendMessage(TextFormat::RED . "%pocketmine.command.weather.wrong");
+			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 			return false;
 		}
 


### PR DESCRIPTION
### Description
Fixes lots of annoying weather bugs, and general cleanup and refinement of weather manager

### Reason to modify
- Fix #1472 - clients who join after the weather changes to rainy would sometimes not receive weather updates
- Fix bugs such as ALWAYS raining/stormy
- Less packet spamming (there's no need to send 4 level event packets for rain/thunder change)
- Less code duplication, more consistency and cleaner code.
- Send a usage message when using /weather without the right parameters in the console instead of saying "Wrong parameters" (such a useless error)

### Tests & Reviews
I have tested the code and everything seems to work flawlessly.