### PR TITLE
Add support for minecart to follow the rails

### DIFF
--- a/src/pocketmine/block/Rail.php
+++ b/src/pocketmine/block/Rail.php
@@ -12,7 +12,19 @@ use pocketmine\math\Vector3;
 use pocketmine\Player;
 
 class Rail extends Flowable{
-
+	
+	const STRAIGHT_EAST_WEST = 0; 
+	const STRAIGHT_NORTH_SOUTH = 1; 
+	const SLOPED_ASCENDING_NORTH = 2;
+	const SLOPED_ASCENDING_SOUTH = 3;
+	const SLOPED_ASCENDING_EAST = 4;  
+	const SLOPED_ASCENDING_WEST = 5;
+	const CURVED_NORTH_WEST = 7; 
+	const CURVED_SOUTH_WEST = 6; 
+	const CURVED_SOUTH_EAST = 9;
+	const CURVED_NORTH_EAST = 8;
+	
+	
 	protected $id = self::RAIL;
 	/** @var Vector3 [] */
 	protected $connected = [];

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -104,6 +104,10 @@ abstract class Entity extends Location implements Metadatable{
 	const DATA_FLAG_ACTION = 4;
 	const DATA_FLAG_INVISIBLE = 5;
 
+	const SOUTH = 0;
+	const WEST = 1;
+	const NORTH = 2;
+	const EAST = 3;
 
 	public static $entityCount = 1;
 	/** @var Entity[] */

--- a/src/pocketmine/entity/Minecart.php
+++ b/src/pocketmine/entity/Minecart.php
@@ -52,7 +52,7 @@ class Minecart extends Vehicle{
 	public $isMoving = false;
 	public $moveSpeed = 0.4;
 	
-	private $onRail = Minecart::STATE_INITIAL;
+	private $state = Minecart::STATE_INITIAL;
 	private $direction = -1;
 	private $moveVector = [];
 	private $requestedPosition = null;
@@ -60,10 +60,6 @@ class Minecart extends Vehicle{
 	public function initEntity(){
 		$this->setMaxHealth(1);
 		$this->setHealth($this->getMaxHealth());
-		$this->moveVector[Entity::NORTH] = new Vector3(-1, 0, 0);
-		$this->moveVector[Entity::SOUTH] = new Vector3(1, 0, 0);
-		$this->moveVector[Entity::EAST] = new Vector3(0, 0, -1);
-		$this->moveVector[Entity::WEST] = new Vector3(0, 0, 1);
 		$this->moveVector[Entity::NORTH] = new Vector3(-1, 0, 0);
 		$this->moveVector[Entity::SOUTH] = new Vector3(1, 0, 0);
 		$this->moveVector[Entity::EAST] = new Vector3(0, 0, -1);
@@ -153,14 +149,39 @@ class Minecart extends Vehicle{
 	 * Check if minecart is currently on a rail and if so center the cart.
 	 */
 	private function checkIfOnRail() {
-		$rail = $this->level->getBlock($this->temporalVector->setComponents($this->x, $this->y - 1, $this->z));
-		if ($rail != null && in_array($rail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
-			$rail = $rail->floor()->add(.5, 0, .5); 
-			$this->setPosition($rail);    // Move minecart to center of rail
-			$this->state = Minecart::STATE_ON_RAIL;
-		} else {
+		for ($y = -1; $y !=2 && $this->state == Minecart::STATE_INITIAL; $y++) {
+			$positionToCheck = $this->temporalVector->setComponents($this->x, $this->y + $y, $this->z);
+			$block = $this->level->getBlock($positionToCheck);
+			if ($this->isRail($block)) {
+				$minecartPosition = $positionToCheck->floor()->add(.5, 0, .5);
+				$this->setPosition($minecartPosition);    // Move minecart to center of rail
+				$this->state = Minecart::STATE_ON_RAIL;
+			}
+		}
+		if ($this->state != Minecart::STATE_ON_RAIL) {
 			$this->state = Minecart::STATE_OFF_RAIL;
 		}
+	}
+	
+	private function isRail($rail) {
+		if ($rail != null && in_array($rail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
+			return true;
+		}
+		return false;
+	}
+	
+	private function getCurrentRail() {
+		$block = $this->getLevel()->getBlock($this);
+		if ($this->isRail($block)) {
+			return $block;
+		} 
+		// Rail could be one block below descending down
+		$down = $this->temporalVector->setComponents($this->x, $this->y - 1, $this->z);
+		$block = $this->getLevel()->getBlock($down);
+		if ($this->isRail($block)) {
+			return $block;
+		}
+		return null;
 	}
 	
 	/**
@@ -175,14 +196,24 @@ class Minecart extends Vehicle{
 		} else {
 			$candidateDirection = $this->direction;
 		}
-		$block = $this->getLevel()->getBlock($this);
-		$railType = $block->getDamage ();
-		$nextDirection = $this->getDirectionToMove($railType, $candidateDirection);
-		if ($nextDirection != -1) {
-			$this->direction = $nextDirection;
-			return $this->moveIfRail();
+		$rail = $this->getCurrentRail();
+		if ($rail != null) {
+			$railType = $rail->getDamage ();
+			$nextDirection = $this->getDirectionToMove($railType, $candidateDirection);
+			if ($nextDirection != -1) {
+				$this->direction = $nextDirection;
+				$moved = $this->checkForVertical($railType, $nextDirection);
+				if (!$moved) {
+					return $this->moveIfRail();
+				} else {
+					return true;
+				}
+			} else {
+				$this->direction = -1;  // Was not able to determine direction to move, so wait for player to look in valid direction
+			}
 		} else {
-			$this->direction = -1;  // Was not able to determine direction to move, so wait for player to look in valid direction
+			// Not able to find rail
+			$this->state = Minecart::STATE_INITIAL;
 		}
 		return false;
 	}
@@ -301,33 +332,131 @@ class Minecart extends Vehicle{
 			case Entity::NORTH:
 				$diff = $this->x - $this->getFloorX();
 				if ($diff != 0 && $diff <= .5) {
-					$this->x = $this->getFloorX() + .5;
+					$dx = ($this->getFloorX() + .5) - $this->x;
+					$this->move($dx, 0, 0);
 					return $newDirection;
 				}
 				break;
 			case Entity::SOUTH:
 				$diff = $this->x - $this->getFloorX();
 				if ($diff != 0 && $diff >= .5) {
-					$this->x = $this->getFloorX() + .5;
+					$dx = ($this->getFloorX() + .5) - $this->x;
+					$this->move($dx, 0, 0);
 					return $newDirection;
 				}
 				break;
 			case Entity::EAST:
 				$diff = $this->z - $this->getFloorZ();
 				if ($diff != 0 && $diff <= .5) {
-					$this->z = $this->getFloorZ() + .5;
+					$dz = ($this->getFloorZ() + .5) - $this->z;
+					$this->move(0, 0, $dz);
 					return $newDirection;
 				}
 				break;
 			case Entity::WEST:
 				$diff = $this->z - $this->getFloorZ();
 				if ($diff != 0 && $diff >= .5) {
-					$this->z = $this->getFloorZ() + .5;
+					$dz = $dz = ($this->getFloorZ() + .5) - $this->z;
+					$this->move(0, 0, $dz);
 					return $newDirection;
 				}
 				break;
 		}
-		return $currentDirection; // Keep going noth until half way.
+		return $currentDirection;
+	}
+	
+	private function checkForVertical($railType, $currentDirection) {
+		switch ($railType) {
+			case Rail::SLOPED_ASCENDING_NORTH:
+				switch($currentDirection) {
+					case Entity::NORTH:
+						// Headed north up
+						$diff = $this->x - $this->getFloorX();
+						if ($diff != 0 && $diff <= .5) {
+							$dx = ($this->getFloorX() - .1) - $this->x;
+							$this->move($dx, 1, 0);
+							return true;
+						}
+						break;
+					case ENTITY::SOUTH:
+						// Headed south down
+						$diff = $this->x - $this->getFloorX();
+						if ($diff != 0 && $diff >= .5) {
+							$dx = ($this->getFloorX() + 1 ) - $this->x;
+							$this->move($dx, -1, 0);
+							return true;
+						}
+						break;
+				}
+				break;
+			case Rail::SLOPED_ASCENDING_SOUTH:
+				switch($currentDirection) {
+					case Entity::SOUTH:
+						// Headed south up
+						$diff = $this->x - $this->getFloorX();
+						if ($diff != 0 && $diff >= .5) {
+							$dx = ($this->getFloorX() + 1 ) - $this->x;
+							$this->move($dx, 1, 0);
+							return true;
+						}
+						break;
+					case Entity::NORTH:
+						// Headed north down
+						$diff = $this->x - $this->getFloorX();
+						if ($diff != 0 && $diff <= .5) {
+							$dx = ($this->getFloorX() - .1) - $this->x;
+							$this->move($dx, -1, 0);
+							return true;
+						}
+						break;
+				}
+				break;
+			case Rail::SLOPED_ASCENDING_EAST:
+				switch($currentDirection) {
+					case Entity::EAST:
+						// Headed east up
+						$diff = $this->z - $this->getFloorZ();
+						if ($diff != 0 && $diff <= .5) {
+							$dz = ($this->getFloorZ() - .1) - $this->z;
+							$this->move(0, 1, $dz);
+							return true;
+						}
+						break;
+					case Entity::WEST:
+						// Headed west down
+						$diff = $this->z - $this->getFloorZ();
+						if ($diff != 0 && $diff >= .5) {
+							$dz = ($this->getFloorZ() + 1) - $this->z;
+							$this->move(0, -1, $dz);
+							return true;
+						}
+						break;
+				}
+				break;
+			case Rail::SLOPED_ASCENDING_WEST:
+				switch($currentDirection) {
+					case Entity::WEST:
+						// Headed west up
+						$diff = $this->z - $this->getFloorZ();
+						if ($diff != 0 && $diff >= .5) {
+							$dz = ($this->getFloorZ() + 1) - $this->z;
+							$this->move(0, 1, $dz);
+							return true;
+						}
+						break;
+					case Entity::EAST:
+						// Headed east down
+						$diff = $this->z - $this->getFloorZ();
+						if ($diff != 0 && $diff <= .5) {
+							$dz = ($this->getFloorZ() - .1) - $this->z;
+							$this->move(0, -1, $dz);
+							return true;
+						}
+						break;
+				}
+				break;
+		}
+		return false;
 	}
 	
 	/**
@@ -338,31 +467,11 @@ class Minecart extends Vehicle{
 		$nextMoveVector = $this->moveVector[$this->direction];
 		$nextMoveVector = $nextMoveVector->multiply($this->moveSpeed);
 		$newVector = $this->add($nextMoveVector->x, $nextMoveVector->y, $nextMoveVector->z);
-		$possibleRail = $this->level->getBlock($newVector);
+		$possibleRail = $this->getCurrentRail();
 		if(in_array($possibleRail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
 			$this->moveUsingVector($newVector);
 			return true;
-		} else {
-			$newVector = $newVector->add(0, -1, 0);
-			// Rail could be one block down since sloping down
-			$possibleRail = $this->level->getBlock($newVector);
-			$damage = $possibleRail->getDamage();
-			if(in_array($possibleRail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
-				$this->moveUsingVector($newVector);
-				return true;
-			} else {
-				$newVector = $newVector->add(0, 2, 0);
-				// Rail could be one block up since sloping up
-				$possibleRail = $this->level->getBlock($newVector);
-				if(in_array($possibleRail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
-					$this->moveUsingVector($newVector);
-					return true;
-				} else {
-					return false;
-					// TODO Need a way to update state to say cart is stuck?
-				}
-			}
-		}
+		} 
 	}
 	
 	/**
@@ -374,14 +483,7 @@ class Minecart extends Vehicle{
 		$dx = $desiredPosition->x - $this->x;
 		$dy = $desiredPosition->y - $this->y;
 		$dz = $desiredPosition->z - $this->z;
-		if ($this->requestedPosition != null && $desiredPosition->x == $this->requestedPosition->x && $desiredPosition->y == $this->requestedPosition->y &&
-			$desiredPosition->z == $this->requestedPosition->z) {
-				// TODO Why doesn't just setting $dy to $dy + 1 work?
-				$upPosition = $this->add(0, 1, 0); // tried $dy = $dy + 1 but didn't work
-				$this->setPosition($upPosition);
-			}
-			$this->requestedPosition = $this->add($dx, $dy, $dz);
-			$this->move($dx, $dy, $dz);
+		$this->move($dx, $dy, $dz);
 	}
 
 

--- a/src/pocketmine/entity/Minecart.php
+++ b/src/pocketmine/entity/Minecart.php
@@ -29,6 +29,7 @@ use pocketmine\Player;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\network\protocol\EntityEventPacket;
 use pocketmine\math\Math;
+use pocketmine\math\Vector3;
 
 class Minecart extends Vehicle{
 	const NETWORK_ID = 84;
@@ -37,19 +38,36 @@ class Minecart extends Vehicle{
 	const TYPE_CHEST = 2;
 	const TYPE_HOPPER = 3;
 	const TYPE_TNT = 4;
+	
+	const STATE_INITIAL = 0;
+	const STATE_ON_RAIL = 1;
+	const STATE_OFF_RAIL = 2;
 
-	public $height = 0.9;
-	public $width = 1.1;
+	public $height = 0.7;
+	public $width = 0.98;
 
 	public $drag = 0.1;
 	public $gravity = 0.5;
 
 	public $isMoving = false;
 	public $moveSpeed = 0.4;
-
+	
+	private $onRail = Minecart::STATE_INITIAL;
+	private $direction = -1;
+	private $moveVector = [];
+	private $requestedPosition = null;
+	
 	public function initEntity(){
 		$this->setMaxHealth(1);
 		$this->setHealth($this->getMaxHealth());
+		$this->moveVector[Entity::NORTH] = new Vector3(-1, 0, 0);
+		$this->moveVector[Entity::SOUTH] = new Vector3(1, 0, 0);
+		$this->moveVector[Entity::EAST] = new Vector3(0, 0, -1);
+		$this->moveVector[Entity::WEST] = new Vector3(0, 0, 1);
+		$this->moveVector[Entity::NORTH] = new Vector3(-1, 0, 0);
+		$this->moveVector[Entity::SOUTH] = new Vector3(1, 0, 0);
+		$this->moveVector[Entity::EAST] = new Vector3(0, 0, -1);
+		$this->moveVector[Entity::WEST] = new Vector3(0, 0, 1);
 		parent::initEntity();
 	}
 
@@ -63,6 +81,11 @@ class Minecart extends Vehicle{
 
 	public function onUpdate($currentTick){
 		if($this->closed !== false){
+			return false;
+		}
+		
+		$tickDiff = $currentTick - $this->lastUpdate;
+		if($tickDiff <= 1){
 			return false;
 		}
 
@@ -110,37 +133,257 @@ class Minecart extends Vehicle{
 			}elseif($movingType == 1){
 				$p = $this->getLinkedEntity();
 				if($p instanceof Player){
-					$rail = $this->getNearestRail();
-					if($rail !== null){
-						$this->setPosition($rail);
-						$motX = -sin($p->getYaw() / 180 * M_PI);
-						$motZ = cos($p->getYaw() / 180 * M_PI);
-						if($motX < 0) $motX = -0.5;
-						elseif($motX > 0) $motX = 0.5;
-						if($motZ < 0) $motZ = -0.5;
-						elseif($motZ > 0) $motZ = 0.5;
-						$block = $this->getLevel()->getBlock($this->add($motX, 0, $motZ)->round());
-						if($block instanceof Rail){
-							if($block->check($rail)){
-								if($block->y > $rail->y) $motY = 1.0;
-								else $motY = 0;
-								$f = sqrt(($motX ** 2) + ($motZ ** 2));
-								$this->yaw = (-atan2($motX, $motZ) * 180 / M_PI);
-								$this->pitch = (-atan2($f, $motY) * 180 / M_PI);
-								$this->move($motX, $motY, $motZ);
-							}
-						}
+					if ($this->state == Minecart::STATE_INITIAL) {
+						$this->checkIfOnRail();
+					}
+					if ($this->state == Minecart::STATE_ON_RAIL) {
+						$hasUpdate = $this->forwardOnRail($p);
 						$this->updateMovement();
 					}
 				}
-				$hasUpdate = true;
 			}
 		}
-
-		$this->timings->stopTiming();
-
-		return $hasUpdate or !$this->onGround or abs($this->motionX) > 0.00001 or abs($this->motionY) > 0.00001 or abs($this->motionZ) > 0.00001;
+		$this->timings->stopTiming ();
+		
+		return $hasUpdate or ! $this->onGround or abs ( $this->motionX ) > 0.00001 or abs ( $this->motionY ) > 0.00001 or abs ( $this->motionZ ) > 0.00001;
 	}
+	
+	
+	/**
+	 * Check if minecart is currently on a rail and if so center the cart.
+	 */
+	private function checkIfOnRail() {
+		$rail = $this->level->getBlock($this->temporalVector->setComponents($this->x, $this->y - 1, $this->z));
+		if ($rail != null && in_array($rail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
+			$rail = $rail->floor()->add(.5, 0, .5); 
+			$this->setPosition($rail);    // Move minecart to center of rail
+			$this->state = Minecart::STATE_ON_RAIL;
+		} else {
+			$this->state = Minecart::STATE_OFF_RAIL;
+		}
+	}
+	
+	/**
+	 * Attempt to move forward on rail given the direction the cart is already moving, or if not moving based
+	 * on the direction the player is looking.
+	 * @param Player $player Player riding the minecart.
+	 * @return boolean True if minecart moved, false otherwise.
+	 */
+	private function forwardOnRail(Player $player) {
+		if ($this->direction == -1) {
+			$candidateDirection = $player->getDirection();			
+		} else {
+			$candidateDirection = $this->direction;
+		}
+		$block = $this->getLevel()->getBlock($this);
+		$railType = $block->getDamage ();
+		$nextDirection = $this->getDirectionToMove($railType, $candidateDirection);
+		if ($nextDirection != -1) {
+			$this->direction = $nextDirection;
+			return $this->moveIfRail();
+		} else {
+			$this->direction = -1;  // Was not able to determine direction to move, so wait for player to look in valid direction
+		}
+		return false;
+	}
+	
+	/**
+	 * Determine the direction the minecart should move based on the candidate direction (current direction
+	 * minecart is moving, or the direction the player is looking) and the type of rail that the minecart is
+	 * on.
+	 * @param RailType $railType Type of rail the minecart is on. 
+	 * @param Direction $candidateDirection Direction minecart already moving, or direction player looking.
+	 * @return Direction The direction the minecart should move.
+	 */
+	private function getDirectionToMove($railType, $candidateDirection) {
+		switch ($railType) {
+			case Rail::STRAIGHT_NORTH_SOUTH :
+				switch ($candidateDirection) {
+					case Entity::NORTH :
+					case Entity::SOUTH :
+						return $candidateDirection;
+				}
+				break;
+			case Rail::STRAIGHT_EAST_WEST :
+				switch ($candidateDirection) {
+					case Entity::WEST :
+					case Entity::EAST :
+						return $candidateDirection;
+				}
+				break;
+			case Rail::SLOPED_ASCENDING_EAST :
+				switch ($candidateDirection) {
+					case Entity::WEST :
+					case Entity::EAST :
+						return $candidateDirection;
+				}
+				break;
+			case Rail::SLOPED_ASCENDING_WEST :
+				switch ($candidateDirection) {
+					case Entity::WEST :
+					case Entity::EAST :
+						return $candidateDirection;
+				}
+				break;
+			case Rail::SLOPED_ASCENDING_NORTH :
+				switch ($candidateDirection) {
+					case Entity::NORTH :
+					case Entity::SOUTH :
+						return $candidateDirection;
+				}
+				break;
+			case Rail::SLOPED_ASCENDING_SOUTH :
+				switch ($candidateDirection) {
+					case Entity::NORTH :
+					case Entity::SOUTH :
+						return $candidateDirection;
+				}
+				break;
+			case Rail::CURVED_SOUTH_EAST :
+				switch ($candidateDirection) {
+					case Entity::SOUTH :
+					case Entity::EAST :
+						return $candidateDirection;
+					case Entity::NORTH :
+						return $this->checkForTurn($candidateDirection, Entity::EAST);
+					case Entity::WEST :
+						return $this->checkForTurn($candidateDirection, Entity::SOUTH);
+				}
+				break;
+			case Rail::CURVED_SOUTH_WEST :
+				switch ($candidateDirection) {
+					case Entity::SOUTH :
+					case Entity::WEST :
+						return $candidateDirection;
+					case Entity::NORTH :
+						return $this->checkForTurn($candidateDirection, Entity::WEST);
+					case Entity::EAST :
+						return $this->checkForTurn($candidateDirection, Entity::SOUTH);
+				}
+				break;
+			case Rail::CURVED_NORTH_WEST :
+				switch ($candidateDirection) {
+					case Entity::NORTH :
+					case Entity::WEST :
+						return $candidateDirection;
+					case Entity::SOUTH :
+						return $this->checkForTurn($candidateDirection, Entity::WEST);
+					case Entity::EAST :
+						return $this->checkForTurn($candidateDirection, Entity::NORTH);
+
+				}
+				break;
+			case Rail::CURVED_NORTH_EAST :
+				switch ($candidateDirection) {
+					case Entity::NORTH :
+					case Entity::EAST :
+						return $candidateDirection;
+					case Entity::SOUTH :
+						return $this->checkForTurn($candidateDirection, Entity::EAST);
+					case Entity::WEST :
+						return $this->checkForTurn($candidateDirection, Entity::NORTH);
+				}
+				break;
+		}
+		return -1;
+	}
+	
+	/**
+	 * Need to alter direction on curves halfway through the turn and reset the minecart to be in the middle of
+	 * the rail again so as not to collide with nearby blocks.
+	 * @param Direction $currentDirection Direction minecart currently moving
+	 * @param Direction $newDirection Direction minecart should turn once has hit the halfway point.
+	 * @return Direction Either the current direction or the new direction depending on haw far across the rail the 
+	 * minecart is.
+	 */
+	private function checkForTurn($currentDirection, $newDirection) {
+		switch($currentDirection) {
+			case Entity::NORTH:
+				$diff = $this->x - $this->getFloorX();
+				if ($diff != 0 && $diff <= .5) {
+					$this->x = $this->getFloorX() + .5;
+					return $newDirection;
+				}
+				break;
+			case Entity::SOUTH:
+				$diff = $this->x - $this->getFloorX();
+				if ($diff != 0 && $diff >= .5) {
+					$this->x = $this->getFloorX() + .5;
+					return $newDirection;
+				}
+				break;
+			case Entity::EAST:
+				$diff = $this->z - $this->getFloorZ();
+				if ($diff != 0 && $diff <= .5) {
+					$this->z = $this->getFloorZ() + .5;
+					return $newDirection;
+				}
+				break;
+			case Entity::WEST:
+				$diff = $this->z - $this->getFloorZ();
+				if ($diff != 0 && $diff >= .5) {
+					$this->z = $this->getFloorZ() + .5;
+					return $newDirection;
+				}
+				break;
+		}
+		return $currentDirection; // Keep going noth until half way.
+	}
+	
+	/**
+	 * Move the minecart as long as it will still be moving on to another piece of rail.
+	 * @return boolean True if the minecart moved.
+	 */
+	private function moveIfRail() {
+		$nextMoveVector = $this->moveVector[$this->direction];
+		$nextMoveVector = $nextMoveVector->multiply($this->moveSpeed);
+		$newVector = $this->add($nextMoveVector->x, $nextMoveVector->y, $nextMoveVector->z);
+		$possibleRail = $this->level->getBlock($newVector);
+		if(in_array($possibleRail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
+			$this->moveUsingVector($newVector);
+			return true;
+		} else {
+			$newVector = $newVector->add(0, -1, 0);
+			// Rail could be one block down since sloping down
+			$possibleRail = $this->level->getBlock($newVector);
+			$damage = $possibleRail->getDamage();
+			if(in_array($possibleRail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
+				$this->moveUsingVector($newVector);
+				return true;
+			} else {
+				$newVector = $newVector->add(0, 2, 0);
+				// Rail could be one block up since sloping up
+				$possibleRail = $this->level->getBlock($newVector);
+				if(in_array($possibleRail->getId(), [Block::RAIL, Block::ACTIVATOR_RAIL, Block::DETECTOR_RAIL, Block::POWERED_RAIL])) {
+					$this->moveUsingVector($newVector);
+					return true;
+				} else {
+					return false;
+					// TODO Need a way to update state to say cart is stuck?
+				}
+			}
+		}
+	}
+	
+	/**
+	 * Invoke the normal move code, but first need to convert the desired position vector into the
+	 * delta values from the current position.
+	 * @param Vector3 $desiredPosition
+	 */
+	private function moveUsingVector(Vector3 $desiredPosition) {
+		$dx = $desiredPosition->x - $this->x;
+		$dy = $desiredPosition->y - $this->y;
+		$dz = $desiredPosition->z - $this->z;
+		if ($this->requestedPosition != null && $desiredPosition->x == $this->requestedPosition->x && $desiredPosition->y == $this->requestedPosition->y &&
+			$desiredPosition->z == $this->requestedPosition->z) {
+				// TODO Why doesn't just setting $dy to $dy + 1 work?
+				$upPosition = $this->add(0, 1, 0); // tried $dy = $dy + 1 but didn't work
+				$this->setPosition($upPosition);
+			}
+			$this->requestedPosition = $this->add($dx, $dy, $dz);
+			$this->move($dx, $dy, $dz);
+	}
+
 
 	/**
 	 * @return Rail


### PR DESCRIPTION
### Description
Added support where minecarts will now follow the rails (when the associated option is set in the genisys.yml file).


### Reason to modify
Currently the minecart will move freely, but it does not follow the rail  I had worked on getting a minecart to follow the rails several months ago on pocketmine, but I wasn't able to figure out how to have the player actually get in the cart (so good job to who ever figured that out).  I have now taken the code I had before for following the rail and ported it to the genisys code (never ended up committing it to pocketmine).


### Tests & Reviews
<!-- Uncomment based on the situation -->

I have tested the code and it works.  I have tried various tracks (curves, up / down), next to blocks, etc.  It seems to work quite well.  There are still some things I would like to improve, but this seemed like a good time to create the pull request as it is functional.

Please review things below:
I am not sure though how to know when a user touches the forward button after entering the cart.  So for the moment the cart starts moving once the player gets in if it is on rail.  
