### PR TITLE
Fixed spectators

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -760,7 +760,7 @@ abstract class Entity extends Location implements Metadatable{
 	}
 
 	public function canCollideWith(Entity $entity){
-		return !$this->justCreated and $entity !== $this;
+		return !$this->justCreated and $entity !== $this and !($entity instanceof Player and !$entity->isSpectator());
 	}
 
 	protected function checkObstruction($x, $y, $z){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1864,7 +1864,7 @@ class Level implements ChunkManager, Metadatable{
 			$entities = $this->getCollidingEntities($hand->getBoundingBox());
 			$realCount = 0;
 			foreach($entities as $e){
-				if($e instanceof Arrow or $e instanceof DroppedItem){
+				if($e instanceof Arrow or $e instanceof DroppedItem or ($e instanceof Player and $e->isSpectator())){
 					continue;
 				}
 				++$realCount;


### PR DESCRIPTION
### Description
Now arrows don't affect spectators, players can build in spectators.

### Reason to modify
In many mini-games, spectators can prevent players to play.

### Tests & Reviews
It's was tested.