### PR TITLE
Fix cannot shoot bow after jump

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3025,8 +3025,10 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						break;
 				}
 
-				$this->startAction = -1;
-				$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_ACTION, false);
+				if($packet->action !== PlayerActionPacket::ACTION_JUMP){
+					$this->startAction = -1;
+					$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_ACTION, false);
+				}
 				break;
 
 			case ProtocolInfo::REMOVE_BLOCK_PACKET:


### PR DESCRIPTION
### Description
Fix cannot shoot bow after jump

### Reason to modify
It prevents $player->startAction from being set to -1 and data flag DATA_FLAG_ACTION from being set to false when server receive a PlayerActionPacket of type ACTION_JUMP when player jumps

### Tests & Reviews
Tested

