### PR TITLE
Fix updateAround bug

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1511,7 +1511,6 @@ class Level implements ChunkManager, Metadatable{
 	 * @return bool Whether the block has been updated or not
 	 */
 	public function setBlock(Vector3 $pos, Block $block, $direct = false, $update = true){
-		$pos = $pos->floor();
 		if($pos->y < 0 or $pos->y >= 128){
 			return false;
 		}


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Fix updateAround bug
updateAround bug
1. put a Jungle wood
2. put 4 cocoBean around this wood.
3. break the Jungle wood.
You will find that only one CocoBean update properly.
### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
It should be.

### Tests & Reviews
<!-- Uncomment based on the situation -->
Tested. But i donot will this cause other bug. 
can any one tell why this bug cause. or give an other solution. 
<!-- I have tested the code and it works. -->

<!-- Please review things below: -->

Fix updateAround bug