### PR TITLE
adjust spawn point to center of block

### DIFF
--- a/src/pocketmine/level/format/generic/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/generic/BaseLevelProvider.php
@@ -97,7 +97,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 	}
 
 	public function getSpawn(){
-		return new Vector3((float) $this->levelData["SpawnX"], (float) $this->levelData["SpawnY"], (float) $this->levelData["SpawnZ"]);
+		return new Vector3((float) $this->levelData["SpawnX"] + 0.5, (float) $this->levelData["SpawnY"], (float) $this->levelData["SpawnZ"] + 0.5);
 	}
 
 	public function setSpawn(Vector3 $pos){


### PR DESCRIPTION
### Description

This PR changes world default spawn to the center of the block, instead of its corner, as per vanilla Minecraft.

### Reason to modify

Because a world we're working on would benefit from being able to accurately position the spawn point on a single block, rather than the middle of 4-blocks thing that's basically enforced now.

### Tests & Reviews

I have tested this, and I am now able to /setworldspawn to the middle of an individual block.
