### PR TITLE
Allow more precise Spawnpoint setting

### DIFF
--- a/src/pocketmine/command/defaults/SetWorldSpawnCommand.php
+++ b/src/pocketmine/command/defaults/SetWorldSpawnCommand.php
@@ -48,7 +48,7 @@ class SetWorldSpawnCommand extends VanillaCommand{
 		if(count($args) === 0){
 			if($sender instanceof Player){
 				$level = $sender->getLevel();
-				$pos = (new Vector3($sender->x, $sender->y, $sender->z))->round();
+				$pos = new Vector3((round($sender->x * 2) / 2), $sender->y, (round($sender->z * 2) / 2));
 			}else{
 				$sender->sendMessage(TextFormat::RED . "You can only perform this command as a player");
 
@@ -65,7 +65,7 @@ class SetWorldSpawnCommand extends VanillaCommand{
 
 		$level->setSpawnLocation($pos);
 
-		Command::broadcastCommandMessage($sender, new TranslationContainer("commands.setworldspawn.success", [round($pos->x, 2), round($pos->y, 2), round($pos->z, 2)]));
+		Command::broadcastCommandMessage($sender, new TranslationContainer("commands.setworldspawn.success", $pos->x, $pos->y, $pos->z));
 
 		return true;
 	}


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Allow setting the spawn location to either the middle of one block, or the middle of 4 blocks, rounding the command sender's location up or down to the nearest half

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
If you have a spawn that is an odd amount of blocks across you can now set the spawn to the exact middle

### Tests & Reviews
<!-- Uncomment based on the situation -->

I have tested the code and it works.

<!-- Please review things below: -->


