### PR TITLE
Standardise $this->server calls

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -384,7 +384,7 @@ class Level implements ChunkManager, Metadatable{
 		$this->levelId = static::$levelIdCounter++;
 		$this->blockMetadata = new BlockMetadataStore($this);
 		$this->server = $server;
-		$this->autoSave = $server->getAutoSave();
+		$this->autoSave = $this->server->getAutoSave();
 
 		/** @var LevelProvider $provider */
 


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
I was chilling around when I saw that

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->

<!-- Please review things below: -->

Now all Server calls are linked to $this->server instead of sometimes $server!