### PR TITLE
Fixes addWindow() not working properly #1594

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4327,11 +4327,10 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 *
 	 * @return int
 	 */
-	public function addWindow(Inventory $inventory, int $forceId = null) : int{
+	public function addWindow(Inventory $inventory, $forceId = null){
 		if($this->windows->contains($inventory)){
 			return $this->windows[$inventory];
 		}
-
 		if($forceId === null){
 			$this->windowCnt = $cnt = max(2, ++$this->windowCnt % 99);
 		}else{
@@ -4343,7 +4342,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			return $cnt;
 		}else{
 			$this->removeWindow($inventory);
-
 			return -1;
 		}
 	}


### PR DESCRIPTION
### Description
Fixes addWindow() not working most of the time.

### Reason to modify
I might sound dumb but I think int tags aren't working properly? Removing them literally fixed it...well at least for me!

### Tests & Reviews
After removing ints, addWindow() started to work flawlessly every single time. I am still *not sure* if this was the only reason behind addWindow() not working. I've tried adding a chest window and it worked. 

