### PR TITLE
Fix ban command.

### DIFF
--- a/src/pocketmine/command/defaults/BanCommand.php
+++ b/src/pocketmine/command/defaults/BanCommand.php
@@ -53,7 +53,7 @@ class BanCommand extends VanillaCommand{
 		if(isset($args[0]) and isset($args[1])){
 			$reason = $args[0];
 			if($args[1] != null and is_numeric($args[1])){
-				$until = $args[1] * 86400 + time();
+				$until = new \DateTime('@' . ($args[1] * 86400 + time()));
 			}else{
 				$until = null;
 			}

--- a/src/pocketmine/command/defaults/BanCommand.php
+++ b/src/pocketmine/command/defaults/BanCommand.php
@@ -59,8 +59,9 @@ class BanCommand extends VanillaCommand{
 			}
 
 			$sender->getServer()->getNameBans()->addBan($name, $reason, $until, $sender->getName());
+		}else{
+			$sender->getServer()->getNameBans()->addBan($name, $reason = implode(" ", $args), null, $sender->getName());
 		}
-		$sender->getServer()->getNameBans()->addBan($name, $reason = implode(" ", $args), null, $sender->getName());
 
 
 		if(($player = $sender->getServer()->getPlayerExact($name)) instanceof Player){


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Fix ban command bug.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Send the ban command with expire value:

> ban username short-reason 10

And you will receive an error:

 > Notice: Object of class DateTime could not be converted to int in phar:///root/19131/PocketMine-MP.phar/src/pocketmine/permission/BanEntry.php on line 74
[22:27:54] [Server thread/INFO]: An unknown error occurred while attempting to perform this command
[22:27:54] [Server thread/CRITICAL]: Unhandled exception executing command 'ban user reason 5' in ban: Call to a member function format() on integer
[22:27:54] [Server thread/CRITICAL]: Error: "Call to a member function format() on integer" (EXCEPTION) in "/src/pocketmine/permission/BanEntry" at line 93

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->

<!-- Please review things below: -->

Until variable must be instance of DateTime or null. Not int.