### PR TITLE
implement PacketReliability constants from RakNet protocol

### DIFF
--- a/src/pocketmine/network/RakLibInterface.php
+++ b/src/pocketmine/network/RakLibInterface.php
@@ -29,6 +29,7 @@ use pocketmine\Player;
 use pocketmine\Server;
 use pocketmine\utils\MainLogger;
 use raklib\protocol\EncapsulatedPacket;
+use raklib\protocol\PacketReliability;
 use raklib\RakLib;
 use raklib\server\RakLibServer;
 use raklib\server\ServerHandler;
@@ -215,7 +216,7 @@ class RakLibInterface implements ServerInstance, AdvancedSourceInterface{
 					$packet->__encapsulatedPacket = new CachedEncapsulatedPacket;
 					$packet->__encapsulatedPacket->identifierACK = null;
 					$packet->__encapsulatedPacket->buffer = chr(0xfe) . $packet->buffer;
-					$packet->__encapsulatedPacket->reliability = 3;
+					$packet->__encapsulatedPacket->reliability = PacketReliability::RELIABLE_ORDERED;
 					$packet->__encapsulatedPacket->orderChannel = 0;
 				}
 				$pk = $packet->__encapsulatedPacket;
@@ -231,7 +232,7 @@ class RakLibInterface implements ServerInstance, AdvancedSourceInterface{
 			if($pk === null){
 				$pk = new EncapsulatedPacket();
 				$pk->buffer = chr(0xfe) . $packet->buffer;
-				$packet->reliability = 3;
+				$packet->reliability = PacketReliability::RELIABLE_ORDERED;
 				$packet->orderChannel = 0;
 
 				if($needACK === true){

--- a/src/raklib/protocol/PacketReliability.php
+++ b/src/raklib/protocol/PacketReliability.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * RakLib network library
+ *
+ *
+ * This project is not affiliated with Jenkins Software LLC nor RakNet.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ */
+
+namespace raklib\protocol;
+
+class PacketReliability {
+	
+	//pure UDP, but will discard duplicate packets
+	const UNRELIABLE = 0;
+
+	//same as unreliable, but will discard messages
+	//that arrive out of order
+	const UNRELIABLE_SEQUENCED = 1;
+
+	//ensures that the packet reaches the destination
+	//but can arrive in any order
+	const RELIABLE = 2;
+
+	//same as reliable, but ensures the packets arrive
+	//in the correct order.
+	const RELIABLE_ORDERED = 3;
+
+	//same as reliable, but out of order messages will be dropped
+	const RELIABLE_SEQUENCED = 4;
+
+	const UNRELIABLE_WITH_ACK_RECEIPT = 5;
+	const RELIABLE_WITH_ACK_RECEIPT = 6;
+
+	//basically the same as TCP
+	const RELIABLE_ORDERED_WITH_ACK_RECEIPT = 7;
+}

--- a/src/raklib/server/Session.php
+++ b/src/raklib/server/Session.php
@@ -30,6 +30,7 @@ use raklib\protocol\OPEN_CONNECTION_REPLY_2;
 use raklib\protocol\OPEN_CONNECTION_REQUEST_1;
 use raklib\protocol\OPEN_CONNECTION_REQUEST_2;
 use raklib\protocol\Packet;
+use raklib\protocol\PacketReliability;
 use raklib\protocol\PING_DataPacket;
 use raklib\protocol\PONG_DataPacket;
 use raklib\protocol\SERVER_HANDSHAKE_DataPacket;
@@ -268,15 +269,15 @@ class Session{
 		}
 
 		if(
-			$packet->reliability === 2 or
-			$packet->reliability === 3 or
-			$packet->reliability === 4 or
-			$packet->reliability === 6 or
-			$packet->reliability === 7
+			$packet->reliability === PacketReliability::RELIABLE or
+			$packet->reliability === PacketReliability::RELIABLE_ORDERED or
+			$packet->reliability === PacketReliability::RELIABLE_SEQUENCED or
+			$packet->reliability === PacketReliability::RELIABLE_WITH_ACK_RECEIPT or
+			$packet->reliability === PacketReliability::RELIABLE_ORDERED_WITH_ACK_RECEIPT
 		){
 			$packet->messageIndex = $this->messageIndex++;
 
-			if($packet->reliability === 3){
+			if($packet->reliability === PacketReliability::RELIABLE_ORDERED){
 				$packet->orderIndex = $this->channelIndex[$packet->orderChannel]++;
 			}
 		}
@@ -297,7 +298,7 @@ class Session{
 				}else{
 					$pk->messageIndex = $packet->messageIndex;
 				}
-				if($pk->reliability === 3){
+				if($pk->reliability === PacketReliability::RELIABLE_ORDERED){
 					$pk->orderChannel = $packet->orderChannel;
 					$pk->orderIndex = $packet->orderIndex;
 				}
@@ -407,7 +408,7 @@ class Session{
 					$pk->encode();
 
 					$sendPacket = new EncapsulatedPacket();
-					$sendPacket->reliability = 0;
+					$sendPacket->reliability = PacketReliability::UNRELIABLE;
 					$sendPacket->buffer = $pk->buffer;
 					$this->addToQueue($sendPacket, RakLib::PRIORITY_IMMEDIATE);
 				}elseif($id === CLIENT_HANDSHAKE_DataPacket::$ID){
@@ -433,7 +434,7 @@ class Session{
 				$pk->encode();
 
 				$sendPacket = new EncapsulatedPacket();
-				$sendPacket->reliability = 0;
+				$sendPacket->reliability = PacketReliability::UNRELIABLE;
 				$sendPacket->buffer = $pk->buffer;
 				$this->addToQueue($sendPacket);
 			}//TODO: add PING/PONG (0x00/0x03) automatic latency measure


### PR DESCRIPTION
### Description
This should enhance RakLib's readability a bit. No more mysterious reliability literals floating around the codebase... I think I got everything down and coded decently enough... This was all taken from the RakNet protocol.


### Reason to modify
Because life is too short to waste it spending time figuring out what a literal is for.

### Tests & Reviews
I've run some tests, and this doesn't seem to break anything. Tell me if I'm wrong though. :)