### PR TITLE
Fix #1583

### DIFF
--- a/src/pocketmine/lang/BaseLang.php
+++ b/src/pocketmine/lang/BaseLang.php
@@ -92,7 +92,7 @@ class BaseLang{
 			$baseText = str_replace("{%$i}", $this->parseTranslation((string) $p), $baseText, $onlyPrefix);
 		}
 
-		return $baseText;
+		return str_replace("%0", "", $baseText); //fixes a client bug where %0 in translation will cause freeze
 	}
 
 	public function translate(TextContainer $c){


### PR DESCRIPTION
### Description
Fixed #1583 -  TextPackets with type TYPE_TRANSLATION and containing %0 causes clients to freeze/crash.

### Reason to modify
Remove exploits used to crash server players.

Some translations are handled automatically by the client if allowed to. My belief is that sending translation key %0 causes an eternal loop while the client searches for a translation string that doesn't exist (#blamemojang). This fixes that by removing %0 from any translation keys.

### Tests & Reviews
I have tested the code and it works. Tested both as client and console, and this can no longer be exploited.