### PR TITLE
Add composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Desktop.ini
 /docs/build/
 !/docs/requirements.txt
 .project
+
+/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ php:
  - 7.0
 
 before_script:
+ - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ - php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+ - php composer-setup.php
+ - php -r "unlink('composer-setup.php');"
+ - ./composer.phar install
  - phpenv config-rm xdebug.ini
  - pecl install channel://pecl.php.net/pthreads-3.1.6
  - pecl install channel://pecl.php.net/weakref-0.3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ php:
  - 7.0
 
 before_script:
- - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
- - php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
- - php composer-setup.php
- - php -r "unlink('composer-setup.php');"
- - ./composer.phar install
  - phpenv config-rm xdebug.ini
  - pecl install channel://pecl.php.net/pthreads-3.1.6
  - pecl install channel://pecl.php.net/weakref-0.3.2

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "itxtech/genisys",
+    "description": "Feature-rich server software for Minecraft: Pocket Edition based on PocketMine-MP",
+    "type": "project",
+    "license": "LGPL-3.0",
+    "require": {}
+}

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php composer-setup.php
+php -r "unlink('composer-setup.php');"
+./composer.phar install
 mkdir plugins
 curl -fsSL https://github.com/iTXTech/Genisys-DevTools/releases/download/1.0.0/Genisys-DevTools_v1.0.0.phar -o plugins/Genisys-DevTools.phar
 echo Running lint...


### PR DESCRIPTION
### Description
Adding Composer to Genisys for managing releases and packages

### Reason to modify
[NIH is a big deal](https://en.wikipedia.org/wiki/Not_invented_here) seriously harming PHP developers all around the globe. Fortunately for you, there is a fix, [Composer](https://getcomposer.org/). This pull request adds Composer to Genisys allowing for package management and just a little more sanity to the project. However, this fix comes at a cost. After adding *any* dependencies, each user who will use Genisys from now on will have to have Composer installed on their system to run Genisys and/or build it to a phar, this does not include pre-built phars, any phars built with Composer will bundle up all the dependencies.

This also opens up some awesome feature capabilities that may have not been previously available without a rewrite from scratch:

- [php-a-star](https://github.com/jmgq/php-a-star) An implementation of the famous A* search algorithm in PHP. This allows you to easily and quickly build mob AI for following players and an AI for animals that includes running away from an attacker
- [php-jwt](https://github.com/firebase/php-jwt) A JWT implementation in pure PHP (the token used in logging in) also includes verifying signatures from logging in players
- [phpecc](https://github.com/phpecc/phpecc) A PHP library that adds support for a bunch of elliptic curves, used in Minecraft: PE's encryption. This will allow a quick and painless implementation of MC: PE encryption in Genisys

... *and the lines become more blurred*