### PR TITLE
Implement hoppers (pickup items, pull items, feed items into target inventories)

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -153,6 +153,7 @@ use pocketmine\tile\Dropper;
 use pocketmine\tile\EnchantTable;
 use pocketmine\tile\FlowerPot;
 use pocketmine\tile\Furnace;
+use pocketmine\tile\Hopper;
 use pocketmine\tile\ItemFrame;
 use pocketmine\tile\MobSpawner;
 use pocketmine\tile\Sign;
@@ -3108,17 +3109,18 @@ class Server{
 
 	private function registerTiles(){
 		Tile::registerTile(BrewingStand::class);
+		Tile::registerTile(Cauldron::class);
 		Tile::registerTile(Chest::class);
-		Tile::registerTile(Furnace::class);
-		Tile::registerTile(Sign::class);
+		Tile::registerTile(Dispenser::class);
+		Tile::registerTile(DLDetector::class);
+		Tile::registerTile(Dropper::class);
 		Tile::registerTile(EnchantTable::class);
 		Tile::registerTile(FlowerPot::class);
-		Tile::registerTile(Skull::class);
-		Tile::registerTile(MobSpawner::class);
+		Tile::registerTile(Furnace::class);
+		Tile::registerTile(Hopper::class);
 		Tile::registerTile(ItemFrame::class);
-		Tile::registerTile(Dispenser::class);
-		Tile::registerTile(Dropper::class);
-		Tile::registerTile(DLDetector::class);
-		Tile::registerTile(Cauldron::class);
+		Tile::registerTile(MobSpawner::class);
+		Tile::registerTile(Sign::class);
+		Tile::registerTile(Skull::class);
 	}
 }

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -305,6 +305,7 @@ class Block extends Position implements BlockIds, Metadatable{
 			self::$list[self::UNPOWERED_REPEATER_BLOCK] = UnpoweredRepeater::class;
 			self::$list[self::CAULDRON_BLOCK] = Cauldron::class;
 			self::$list[self::INVISIBLE_BEDROCK] = InvisibleBedrock::class;
+			self::$list[self::HOPPER_BLOCK] = Hopper::class;
 
 			foreach(self::$list as $id => $class){
 				if($class !== null){

--- a/src/pocketmine/block/Hopper.php
+++ b/src/pocketmine/block/Hopper.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ *
+ *  _____   _____   __   _   _   _____  __    __  _____
+ * /  ___| | ____| |  \ | | | | /  ___/ \ \  / / /  ___/
+ * | |     | |__   |   \| | | | | |___   \ \/ /  | |___
+ * | |  _  |  __|  | |\   | | | \___  \   \  /   \___  \
+ * | |_| | | |___  | | \  | | |  ___| |   / /     ___| |
+ * \_____/ |_____| |_|  \_| |_| /_____/  /_/     /_____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author iTX Technologies
+ * @link https://itxtech.org
+ *
+ */
+
+namespace pocketmine\block;
+
+use pocketmine\item\Item;
+use pocketmine\nbt\NBT;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\IntTag;
+use pocketmine\nbt\tag\StringTag;
+use pocketmine\Player;
+use pocketmine\tile\Hopper as TileHopper;
+use pocketmine\tile\Tile;
+
+class Hopper extends Transparent{
+
+	protected $id = self::HOPPER_BLOCK;
+
+	public function __construct($meta = 0){
+		$this->meta = $meta;
+	}
+
+	public function canBeActivated(): bool{
+		return true;
+	}
+
+	public function getToolType(){
+		return Tool::TYPE_PICKAXE;
+	}
+
+	public function getName() : string{
+		return "Hopper";
+	}
+
+	public function getHardness(){
+		return 3;
+	}
+
+	public function onActivate(Item $item, Player $player = null){
+		if($player instanceof Player){
+			$t = $this->getLevel()->getTile($this);
+			if($t instanceof TileHopper){
+				if($t->hasLock() and !$t->checkLock($item->getCustomName())){
+					$player->getServer()->getLogger()->debug($player->getName() . " attempted to open a locked hopper");
+					return true;
+				}
+				$player->addWindow($t->getInventory());
+			}
+		}
+		return true;
+	}
+	
+	public function activate(){
+		//TODO: Hopper content freezing (requires basic redstone system upgrade)
+	}
+	
+	public function getTarget(){
+		return $this->target;
+	}
+
+	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
+		$faces = [
+			0 => 0,
+			1 => 0,
+			2 => 3,
+			3 => 2,
+			4 => 5,
+			5 => 4
+		];
+		$this->meta = $faces[$face];
+		$this->getLevel()->setBlock($block, $this, true, true);
+
+		$nbt = new CompoundTag("", [
+			new ListTag("Items", []),
+			new StringTag("id", Tile::HOPPER),
+			new IntTag("x", $this->x),
+			new IntTag("y", $this->y),
+			new IntTag("z", $this->z)
+		]);
+		$nbt->Items->setTagType(NBT::TAG_Compound);
+
+		if($item->hasCustomName()){
+			$nbt->CustomName = new StringTag("CustomName", $item->getCustomName());
+		}
+
+		if($item->hasCustomBlockData()){
+			foreach($item->getCustomBlockData() as $key => $v){
+				$nbt->{$key} = $v;
+			}
+		}
+
+		$t = Tile::createTile(Tile::HOPPER, $this->getLevel()->getChunk($this->x >> 4, $this->z >> 4), $nbt);
+
+		return true;
+	}
+
+	public function getDrops(Item $item) : array {
+		if($item->isPickaxe() >= 1){
+			return [
+				[Item::HOPPER, 0, 1],
+			];
+		}else{
+			return [];
+		}
+	}
+}

--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -235,6 +235,15 @@ abstract class BaseInventory implements Inventory{
 
 		return -1;
 	}
+	
+	public function firstOccupied(){
+		for($i = 0; $i < $this->size; $i++){
+			if(($item = $this->getItem($i))->getId() !== Item::AIR and $item->getCount() > 0){
+				return $i;
+			}
+		}
+		return -1;
+	}
 
 	public function canAddItem(Item $item){
 		$item = clone $item;

--- a/src/pocketmine/inventory/HopperInventory.php
+++ b/src/pocketmine/inventory/HopperInventory.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *  _____   _____   __   _   _   _____  __    __  _____
+ * /  ___| | ____| |  \ | | | | /  ___/ \ \  / / /  ___/
+ * | |     | |__   |   \| | | | | |___   \ \/ /  | |___
+ * | |  _  |  __|  | |\   | | | \___  \   \  /   \___  \
+ * | |_| | | |___  | | \  | | |  ___| |   / /     ___| |
+ * \_____/ |_____| |_|  \_| |_| /_____/  /_/     /_____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author iTX Technologies
+ * @link https://itxtech.org
+ *
+ */
+
+namespace pocketmine\inventory;
+
+use pocketmine\tile\Hopper;
+
+class HopperInventory extends ContainerInventory{
+	public function __construct(Hopper $tile){
+		parent::__construct($tile, InventoryType::get(InventoryType::HOPPER));
+	}
+
+	/**
+	 * @return Hopper
+	 */
+	public function getHolder(){
+		return $this->holder;
+	}
+}

--- a/src/pocketmine/item/Hopper.php
+++ b/src/pocketmine/item/Hopper.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ *
+ *  _____   _____   __   _   _   _____  __    __  _____
+ * /  ___| | ____| |  \ | | | | /  ___/ \ \  / / /  ___/
+ * | |     | |__   |   \| | | | | |___   \ \/ /  | |___
+ * | |  _  |  __|  | |\   | | | \___  \   \  /   \___  \
+ * | |_| | | |___  | | \  | | |  ___| |   / /     ___| |
+ * \_____/ |_____| |_|  \_| |_| /_____/  /_/     /_____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author iTX Technologies
+ * @link https://itxtech.org
+ *
+ */
+
+namespace pocketmine\item;
+
+use pocketmine\block\Block;
+
+class Hopper extends Item{
+	public function __construct($meta = 0, $count = 1){
+		$this->block = Block::get(Block::HOPPER_BLOCK);
+		parent::__construct(self::HOPPER, 0, $count, "Hopper");
+	}
+}

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -80,6 +80,7 @@ class Item implements ItemIds{
 
 	public static function init($readFromJson = false){
 		if(self::$list === null){
+			//TODO: Sort this mess into some kind of order
 			self::$list = new \SplFixedArray(65536);
 			self::$list[self::SUGARCANE] = Sugarcane::class;
 			self::$list[self::WHEAT_SEEDS] = WheatSeeds::class;
@@ -232,6 +233,7 @@ class Item implements ItemIds{
 			self::$list[self::ENCHANTED_GOLDEN_APPLE] = EnchantedGoldenApple::class;
 			self::$list[self::RAW_MUTTON] = RawMutton::class;
 			self::$list[self::COOKED_MUTTON] = CookedMutton::class;
+			self::$list[self::HOPPER] = Hopper::class;
 
 			for($i = 0; $i < 256; ++$i){
 				if(Block::$list[$i] !== null){

--- a/src/pocketmine/tile/Hopper.php
+++ b/src/pocketmine/tile/Hopper.php
@@ -1,0 +1,309 @@
+<?php
+
+/*
+ *
+ *  _____   _____   __   _   _   _____  __    __  _____
+ * /  ___| | ____| |  \ | | | | /  ___/ \ \  / / /  ___/
+ * | |     | |__   |   \| | | | | |___   \ \/ /  | |___
+ * | |  _  |  __|  | |\   | | | \___  \   \  /   \___  \
+ * | |_| | | |___  | | \  | | |  ___| |   / /     ___| |
+ * \_____/ |_____| |_|  \_| |_| /_____/  /_/     /_____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author iTX Technologies
+ * @link https://itxtech.org
+ *
+ */
+
+namespace pocketmine\tile;
+
+use pocketmine\block\Hopper as HopperBlock;
+use pocketmine\entity\Item as DroppedItem;
+use pocketmine\inventory\HopperInventory;
+use pocketmine\inventory\InventoryHolder;
+use pocketmine\item\Item;
+use pocketmine\level\format\FullChunk;
+use pocketmine\math\Vector3;
+use pocketmine\nbt\NBT;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\IntTag;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\StringTag;
+
+class Hopper extends Spawnable implements InventoryHolder, Container, Nameable{
+	/** @var HopperInventory */
+	protected $inventory;
+
+	/** @var bool */
+	protected $isLocked = false;
+	
+	/** @var bool */
+	protected $isPowered = false;
+
+	public function __construct(FullChunk $chunk, CompoundTag $nbt){
+		parent::__construct($chunk, $nbt);
+		$this->inventory = new HopperInventory($this);
+
+		if(!isset($this->namedtag->Items) or !($this->namedtag->Items instanceof ListTag)){
+			$this->namedtag->Items = new ListTag("Items", []);
+			$this->namedtag->Items->setTagType(NBT::TAG_Compound);
+		}
+
+		for($i = 0; $i < $this->getSize(); ++$i){
+			$this->inventory->setItem($i, $this->getItem($i));
+		}
+		$this->namedtag->TransferCooldown = new IntTag("TransferCooldown", 0);
+
+		$this->scheduleUpdate();
+	}
+
+	public function close(){
+		if($this->closed === false){
+			foreach($this->getInventory()->getViewers() as $player){
+				$player->removeWindow($this->getInventory());
+			}
+
+			foreach($this->getInventory()->getViewers() as $player){
+				$player->removeWindow($this->getInventory());
+			}
+			parent::close();
+		}
+	}
+	
+	public function activate(){
+		$this->isPowered = true;
+	}
+	
+	public function deactivate(){
+		$this->isPowered = false;
+	}
+
+	public function canUpdate(){
+		return $this->namedtag->TransferCooldown->getValue() === 0 and !$this->isPowered;
+	}
+
+	public function resetCooldownTicks(){
+		$this->namedtag->TransferCooldown->setValue(8);
+	}
+
+	public function onUpdate(){
+		if(!($this->getBlock() instanceof HopperBlock)){
+			return false;
+		}
+		//Pickup dropped items
+		//This can happen at any time regardless of cooldown
+		$area = clone $this->getBlock()->getBoundingBox(); //Area above hopper to draw items from
+		$area->maxY = ceil($area->maxY) + 1; //Account for full block above, not just 1 + 5/8
+		foreach($this->getLevel()->getChunkEntities($this->getBlock()->x >> 4, $this->getBlock()->z >> 4) as $entity){
+			if(!($entity instanceof DroppedItem)){
+				continue;
+			}
+			if(!$entity->boundingBox->intersectsWith($area)){
+				continue;
+			}
+
+			$item = $entity->getItem();
+			if(!$item instanceof Item){
+				continue;
+			}
+			if($item->getCount() < 1){
+				$entity->kill();
+				continue;
+			}
+
+			if($this->inventory->canAddItem($item)){
+				$this->inventory->addItem($item);
+				$entity->kill();
+			}
+		}
+
+		if(!$this->canUpdate()){ //Hoppers only update CONTENTS every 8th tick
+			$this->namedtag->TransferCooldown->setValue($this->namedtag->TransferCooldown->getValue() - 1);
+			return true;
+		}
+		
+		//Suck items from above tile inventories
+		$source = $this->getLevel()->getTile($this->getBlock()->getSide(Vector3::SIDE_UP));
+		if($source instanceof Tile and $source instanceof InventoryHolder){
+			$inventory = $source->getInventory();
+			$item = clone $inventory->getItem($inventory->firstOccupied());
+			$item->setCount(1);
+			if($this->inventory->canAddItem($item)){
+				$this->inventory->addItem($item);
+				$inventory->removeItem($item);
+				$this->resetCooldownTicks();
+				if($source instanceof Hopper){
+					$source->resetCooldownTicks();
+				}
+			}
+		}
+		
+		//Feed item into target inventory
+		//Do not do this if there's a hopper underneath this hopper, to follow vanilla behaviour
+		if(!($this->getLevel()->getTile($this->getBlock()->getSide(Vector3::SIDE_DOWN)) instanceof Hopper)){
+			$target = $this->getLevel()->getTile($this->getBlock()->getSide($this->getBlock()->getDamage()));
+			if($target instanceof Tile and $target instanceof InventoryHolder){
+				$inv = $target->getInventory();
+				foreach($this->inventory->getContents() as $item){
+					if($item->getId() === Item::AIR or $item->getCount() < 1){
+						continue;
+					}
+					$targetItem = clone $item;
+					$targetItem->setCount(1);
+					
+					if($inv->canAddItem($targetItem)){
+						$inv->addItem($targetItem);
+						$this->inventory->removeItem($targetItem);
+						$this->resetCooldownTicks();
+						if($target instanceof Hopper){
+							$target->resetCooldownTicks();
+						}
+						break;
+					}
+					
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * @return HopperInventory
+	 */
+	public function getInventory(){
+		return $this->inventory;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getSize(){
+		return 5;
+	}
+
+	/**
+	 * This method should not be used by plugins, use the Inventory
+	 *
+	 * @param int $index
+	 *
+	 * @return Item
+	 */
+	public function getItem($index){
+		$i = $this->getSlotIndex($index);
+		if($i < 0){
+			return Item::get(Item::AIR, 0, 0);
+		}else{
+			return NBT::getItemHelper($this->namedtag->Items[$i]);
+		}
+	}
+
+	/**
+	 * This method should not be used by plugins, use the Inventory
+	 *
+	 * @param int  $index
+	 * @param Item $item
+	 *
+	 * @return bool
+	 */
+	public function setItem($index, Item $item){
+		$i = $this->getSlotIndex($index);
+
+		$d = NBT::putItemHelper($item, $index);
+
+		if($item->getId() === Item::AIR or $item->getCount() <= 0){
+			if($i >= 0){
+				unset($this->namedtag->Items[$i]);
+			}
+		}elseif($i < 0){
+			for($i = 0; $i <= $this->getSize(); ++$i){
+				if(!isset($this->namedtag->Items[$i])){
+					break;
+				}
+			}
+			$this->namedtag->Items[$i] = $d;
+		}else{
+			$this->namedtag->Items[$i] = $d;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param $index
+	 *
+	 * @return int
+	 */
+	protected function getSlotIndex($index){
+		foreach($this->namedtag->Items as $i => $slot){
+			if((int) $slot["Slot"] === (int) $index){
+				return (int) $i;
+			}
+		}
+
+		return -1;
+	}
+
+	public function saveNBT(){
+		$this->namedtag->Items = new ListTag("Items", []);
+		$this->namedtag->Items->setTagType(NBT::TAG_Compound);
+		for($index = 0; $index < $this->getSize(); ++$index){
+			$this->setItem($index, $this->inventory->getItem($index));
+		}
+	}
+
+	public function getName() : string{
+		return isset($this->namedtag->CustomName) ? $this->namedtag->CustomName->getValue() : "Hopper";
+	}
+
+	public function hasName(){
+		return isset($this->namedtag->CustomName);
+	}
+
+	public function setName($str){
+		if($str === ""){
+			unset($this->namedtag->CustomName);
+			return;
+		}
+		$this->namedtag->CustomName = new StringTag("CustomName", $str);
+	}
+
+
+	public function hasLock(){
+		return isset($this->namedtag->Lock);
+	}
+
+	public function setLock(string $itemName = ""){
+		if($itemName === ""){
+			unset($this->namedtag->Lock);
+			return;
+		}
+		$this->namedtag->Lock = new StringTag("Lock", $itemName);
+	}
+	
+	public function checkLock(string $key){
+		return $this->namedtag->Lock->getValue() === $key;
+	}
+
+	public function getSpawnCompound(){
+		$c = new CompoundTag("", [
+			new StringTag("id", Tile::HOPPER),
+			new IntTag("x", (int) $this->x),
+			new IntTag("y", (int) $this->y),
+			new IntTag("z", (int) $this->z)
+		]);
+
+		if($this->hasName()){
+			$c->CustomName = $this->namedtag->CustomName;
+		}
+		if($this->hasLock()){
+			$c->Lock = $this->namedtag->Lock;
+		}
+
+		return $c;
+	}
+}

--- a/src/pocketmine/tile/Tile.php
+++ b/src/pocketmine/tile/Tile.php
@@ -48,6 +48,7 @@ abstract class Tile extends Position{
 	const DROPPER = "Dropper";
 	const DAY_LIGHT_DETECTOR = "DLDetector";
 	const CAULDRON = "Cauldron";
+	const HOPPER = "Hopper";
 
 	public static $tileCount = 1;
 


### PR DESCRIPTION
## Description
Added hoppers, with the ability to pull items from tile inventories, pick up dropped items and feed items into inventories.

Hoppers will pull items down from any *permanent* tile inventory above them, and also pick up dropped items. Directional feeding also works - i.e. hoppers will feed into the inventory they are pointing at.

### Known issues
- Powering a hopper does not currently prevent it processing items. This is because of the shoddy implementation of redstone making it difficult to activate/deactivate blocks.
- All slots of inventories are currently treated the same. This means that hoppers can, for example, feed into furnace result slots and pull items out of the target and/or fuel slot. This will be corrected at a later date when I upgrade inventory and crafting base functionality.
- Hopper locking (only opens when player clicks on the hopper with an item with a matching custom name) is impossible to use because of the lack of a /blockdata command. The functionality has however been implemented.

## Reason to modify
People want hoppers, so let's _give_ them hoppers.

## Tests & Reviews
I have done my best to ensure that the behaviour follows the behaviour defined [here](http://minecraft.gamepedia.com/Hopper) ~~with a few exceptions to line up with current MCPE hopper behaviour.~~ EDIT: I've had information from certain sources which leads me to believe that current MCPE hopper pickup behaviour is bugged, so I have followed the PC guidelines instead.
To the best of my knowledge, everything works fine. Tested on Windows 10, with Win10 Edition and MCPE. Please test and confirm.