### PR TITLE
Added Effect Events (EntityEffectAddEvent, EntityEffectRemoveEvent)

### DIFF
--- a/src/pocketmine/command/defaults/EffectCommand.php
+++ b/src/pocketmine/command/defaults/EffectCommand.php
@@ -114,13 +114,15 @@ class EffectCommand extends VanillaCommand{
 				return true;
 			}
 
-			$player->removeEffect($effect->getId());
-			$sender->sendMessage(new TranslationContainer("commands.effect.success.removed", [$effect->getName(), $player->getDisplayName()]));
+			if ($player->removeEffect($effect->getId())) {
+				$sender->sendMessage(new TranslationContainer("commands.effect.success.removed", [$effect->getName(), $player->getDisplayName()]));
+			}
 		}else{
 			$effect->setDuration($duration)->setAmplifier($amplification);
 
-			$player->addEffect($effect);
-			self::broadcastCommandMessage($sender, new TranslationContainer("%commands.effect.success", [$effect->getName(), $effect->getId(), $effect->getAmplifier(), $player->getDisplayName(), $effect->getDuration() / 20]));
+			if ($player->addEffect($effect)) {
+				self::broadcastCommandMessage($sender, new TranslationContainer("%commands.effect.success", [$effect->getName(), $effect->getId(), $effect->getAmplifier(), $player->getDisplayName(), $effect->getDuration() / 20]));
+			}
 		}
 
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -32,6 +32,8 @@ use pocketmine\block\Water;
 use pocketmine\block\SlimeBlock;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\EntityDespawnEvent;
+use pocketmine\event\entity\EntityEffectAddEvent;
+use pocketmine\event\entity\EntityEffectRemoveEvent;
 use pocketmine\event\entity\EntityLevelChangeEvent;
 use pocketmine\event\entity\EntityMotionEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
@@ -378,6 +380,10 @@ abstract class Entity extends Location implements Metadatable{
 	}
 
 	public function removeEffect($effectId){
+		Server::getInstance()->getPluginManager()->callEvent($ev = new EntityEffectRemoveEvent($this, $effectId));
+		if($ev->isCancelled()){
+			return false;
+		}
 		if(isset($this->effects[$effectId])){
 			$effect = $this->effects[$effectId];
 			unset($this->effects[$effectId]);
@@ -387,6 +393,7 @@ abstract class Entity extends Location implements Metadatable{
 			}
 
 			$this->recalculateEffectColor();
+			return true;
 		}
 	}
 
@@ -399,6 +406,10 @@ abstract class Entity extends Location implements Metadatable{
 	}
 
 	public function addEffect(Effect $effect){
+		Server::getInstance()->getPluginManager()->callEvent($ev = new EntityEffectAddEvent($this, $effect));
+		if($ev->isCancelled()){
+			return false;
+		}
 		if($effect->getId() === Effect::HEALTH_BOOST){
 			$this->setHealth($this->getHealth() + 4 * ($effect->getAmplifier() + 1));
 		}
@@ -419,6 +430,7 @@ abstract class Entity extends Location implements Metadatable{
 		$this->effects[$effect->getId()] = $effect;
 
 		$this->recalculateEffectColor();
+		return true;
 	}
 
 	protected function recalculateEffectColor(){

--- a/src/pocketmine/event/entity/EntityEffectAddEvent.php
+++ b/src/pocketmine/event/entity/EntityEffectAddEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link   http://www.pocketmine.net/
+ *
+ *
+ */
+
+namespace pocketmine\event\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\Event;
+use pocketmine\event\Cancellable;
+use pocketmine\entity\Effect;
+
+class EntityEffectAddEvent extends EntityEvent implements Cancellable{
+
+	public static $handlerList = null;
+
+	public function __construct(Entity $entity, Effect $effect){
+		$this->entity = $entity;
+		$this->effect = $effect;;
+	}
+
+}

--- a/src/pocketmine/event/entity/EntityEffectRemoveEvent.php
+++ b/src/pocketmine/event/entity/EntityEffectRemoveEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link   http://www.pocketmine.net/
+ *
+ *
+ */
+
+namespace pocketmine\event\entity;
+
+use pocketmine\entity\Entity;
+use pocketmine\Event;
+use pocketmine\event\Cancellable;
+use pocketmine\entity\Effect;
+
+class EntityEffectRemoveEvent extends EntityEvent implements Cancellable{
+
+	public static $handlerList = null;
+
+	public function __construct(Entity $entity, int $effect){
+		$this->entity = $entity;
+		$this->effect = $effect;;
+	}
+
+}


### PR DESCRIPTION
### Description
This adds the ability for plugins to listen to EntityEffectAddEvent and EntityEffectRemoveEvent, which was requested by some guy on Gitter. Figured I'd throw it in here, since it may come in handy. :)


### Reason to modify
These events don't exist at the moment, and may come in handy, so here they are!

### Tests & Reviews
I've tested these events, and they work as advertised. The command is also silent when the events are cancelled, and works correctly otherwise.