### PR TITLE
Painting: Fix rotation when placed.

### DIFF
--- a/src/pocketmine/entity/Painting.php
+++ b/src/pocketmine/entity/Painting.php
@@ -45,6 +45,10 @@ class Painting extends Hanging{
 		parent::spawnTo($player);
 	}
 
+	protected function updateMovement(){
+		//Nothing to update, paintings cannot move.
+	}
+
 	public function getDrops(){
 		return [ItemItem::get(ItemItem::PAINTING, 0, 1)];
 	}


### PR DESCRIPTION
### Description
Fixed paintings rotating when placed. Close #1138

### Reason to modify
Entity movement is updated when creating the entity. This should not happen for paintings since paintings cannot move. This PR corrects that problem by overriding the method with an empty method.

### Tests & Reviews
Tested, found fully working with PE 0.15.6.