### PR TITLE
You must support PHP without openssl!

### DIFF
--- a/src/pocketmine/network/protocol/LoginPacket.php
+++ b/src/pocketmine/network/protocol/LoginPacket.php
@@ -125,7 +125,7 @@ class LoginPacket extends DataPacket{
 			$derSig .= chr(2) . chr($l);
 			$derSig .= str_repeat(chr(0), $l - $k) . substr($sig, 2 * $rawLen - $k, $k);
 
-			$verified = openssl_verify($headB64 . "." . $payloadB64, $derSig, "-----BEGIN PUBLIC KEY-----\n" . wordwrap($key, 64, "\n", true) . "\n-----END PUBLIC KEY-----\n", OPENSSL_ALGO_SHA384) === 1;
+			$verified = function_exists('openssl_verify') && openssl_verify($headB64 . "." . $payloadB64, $derSig, "-----BEGIN PUBLIC KEY-----\n" . wordwrap($key, 64, "\n", true) . "\n-----END PUBLIC KEY-----\n", OPENSSL_ALGO_SHA384) === 1;
 		}else{
 			$verified = false;
 		}

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -34,6 +34,21 @@ class Utils{
 	public static $os;
 	private static $serverUniqueId = null;
 
+	public static function random_pseudo_bytes($length) {
+		$number_table=array();
+		$result='';
+		while($length-->0) {
+			if(count($number_table)==0) {
+				for($i=0;$i<256;$i++) {
+					$number_table[]=$i;
+					shuffle($number_table);
+				}
+			}
+			$result.=chr(array_shift($number_table));
+		}
+		return $result;
+	}
+	
 	/**
 	 * Generates an unique identifier to a callable
 	 *
@@ -435,7 +450,7 @@ class Utils{
 				$strongEntropyValues = [
 					is_array($startEntropy) ? hash("sha512", $startEntropy[($rounds + $drop) % count($startEntropy)], true) : hash("sha512", $startEntropy, true), //Get a random index of the startEntropy, or just read it
 					$systemRandom,
-					openssl_random_pseudo_bytes(64),
+					self::random_pseudo_bytes(64),
 					$value,
 				];
 				$strongEntropy = array_pop($strongEntropyValues);


### PR DESCRIPTION
### Description
To support PHP without openssl.


### Reason to modify
Too many users is using PHP binaries without openssl,this will available them to continue use this core.
