### PR TITLE
Improve random bytes generation.

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -451,7 +451,7 @@ namespace pocketmine {
 
 	@define("ENDIANNESS", (pack("d", 1) === "\77\360\0\0\0\0\0\0" ? Binary::BIG_ENDIAN : Binary::LITTLE_ENDIAN));
 	@define("INT32_MASK", is_int(0xffffffff) ? 0xffffffff : -1);
-	@ini_set("opcache.mmap_base", bin2hex(Utils::getRandomBytes(8, false))); //Fix OPCache address errors
+	@ini_set("opcache.mmap_base", bin2hex(random_bytes(8))); //Fix OPCache address errors
 
 	$lang = "unknown";
 	if(!file_exists(\pocketmine\DATA . "server.properties") and !isset($opts["no-wizard"])){

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1288,7 +1288,7 @@ class Server{
 			return false;
 		}
 
-		$seed = $seed === null ? Binary::readInt(@Utils::getRandomBytes(4, false)) : (int) $seed;
+		$seed = $seed === null ? Binary::readInt(random_bytes(4)) : (int) $seed;
 
 		if(!isset($options["preset"])){
 			$options["preset"] = $this->getConfigString("generator-settings", "");
@@ -1886,7 +1886,7 @@ class Server{
 				"level-type" => "DEFAULT",
 				"enable-query" => true,
 				"enable-rcon" => false,
-				"rcon.password" => substr(base64_encode(@Utils::getRandomBytes(20, false)), 3, 10),
+				"rcon.password" => substr(base64_encode(random_bytes(20)), 3, 10),
 				"auto-save" => true,
 				"online-mode" => false,
 			]);

--- a/src/pocketmine/network/query/QueryHandler.php
+++ b/src/pocketmine/network/query/QueryHandler.php
@@ -65,7 +65,7 @@ class QueryHandler{
 
 	public function regenerateToken(){
 		$this->lastToken = $this->token;
-		$this->token = @Utils::getRandomBytes(16, false);
+		$this->token = random_bytes(16);
 	}
 
 	public static function getTokenString($token, $salt){

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -362,6 +362,7 @@ class Utils{
 	/**
 	 * This function tries to get all the entropy available in PHP, and distills it to get a good RNG.
 	 *
+	 * This function simply forwards to the PHP random_bytes function.
 	 *
 	 * @param int    $length       default 16, Number of bytes to generate
 	 * @param bool   $secure       default true, Generate secure distilled bytes, slower
@@ -370,108 +371,16 @@ class Utils{
 	 * @param int    &$rounds      Will be set to the number of rounds taken
 	 * @param int    &$drop        Will be set to the amount of dropped bytes
 	 *
+	 * @deprecated prefer PHP 7 random_bytes()
 	 * @return string
 	 */
 	public static function getRandomBytes($length = 16, $secure = true, $raw = true, $startEntropy = "", &$rounds = 0, &$drop = 0){
-		static $lastRandom = "";
-		$output = "";
-		$length = abs((int) $length);
-		$secureValue = "";
-		$rounds = 0;
-		$drop = 0;
-		while(!isset($output{$length - 1})){
-			//some entropy, but works ^^
-			$weakEntropy = [
-				is_array($startEntropy) ? implode($startEntropy) : $startEntropy,
-				__DIR__,
-				PHP_OS,
-				microtime(),
-				(string) lcg_value(),
-				(string) PHP_MAXPATHLEN,
-				PHP_SAPI,
-				(string) PHP_INT_MAX . "." . PHP_INT_SIZE,
-				serialize($_SERVER),
-				get_current_user(),
-				(string) memory_get_usage() . "." . memory_get_peak_usage(),
-				php_uname(),
-				phpversion(),
-				zend_version(),
-				(string) getmypid(),
-				(string) getmyuid(),
-				(string) mt_rand(),
-				(string) getmyinode(),
-				(string) getmygid(),
-				(string) rand(),
-				function_exists("zend_thread_id") ? ((string) zend_thread_id()) : microtime(),
-				function_exists("getrusage") ? implode(getrusage()) : microtime(),
-				function_exists("sys_getloadavg") ? implode(sys_getloadavg()) : microtime(),
-				serialize(get_loaded_extensions()),
-				sys_get_temp_dir(),
-				(string) disk_free_space("."),
-				(string) disk_total_space("."),
-				uniqid(microtime(), true),
-				file_exists("/proc/cpuinfo") ? file_get_contents("/proc/cpuinfo") : microtime(),
-			];
-
-			shuffle($weakEntropy);
-			$value = hash("sha512", implode($weakEntropy), true);
-			$lastRandom .= $value;
-			foreach($weakEntropy as $k => $c){ //mixing entropy values with XOR and hash randomness extractor
-				$value ^= hash("sha256", $c . microtime() . $k, true) . hash("sha256", mt_rand() . microtime() . $k . $c, true);
-				$value ^= hash("sha512", ((string) lcg_value()) . $c . microtime() . $k, true);
-			}
-			unset($weakEntropy);
-
-			if($secure === true){
-
-				if(file_exists("/dev/urandom")){
-					$fp = fopen("/dev/urandom", "rb");
-					$systemRandom = fread($fp, 64);
-					fclose($fp);
-				}else{
-					$systemRandom = str_repeat("\x00", 64);
-				}
-
-				$strongEntropyValues = [
-					is_array($startEntropy) ? hash("sha512", $startEntropy[($rounds + $drop) % count($startEntropy)], true) : hash("sha512", $startEntropy, true), //Get a random index of the startEntropy, or just read it
-					$systemRandom,
-					function_exists("openssl_random_pseudo_bytes") ? openssl_random_pseudo_bytes(64) : str_repeat("\x00", 64),
-					$value,
-				];
-				$strongEntropy = array_pop($strongEntropyValues);
-				foreach($strongEntropyValues as $value){
-					$strongEntropy = $strongEntropy ^ $value;
-				}
-				$value = "";
-				//Von Neumann randomness extractor, increases entropy
-				$bitcnt = 0;
-				for($j = 0; $j < 64; ++$j){
-					$a = ord($strongEntropy{$j});
-					for($i = 0; $i < 8; $i += 2){
-						$b = ($a & (1 << $i)) > 0 ? 1 : 0;
-						if($b != (($a & (1 << ($i + 1))) > 0 ? 1 : 0)){
-							$secureValue |= $b << $bitcnt;
-							if($bitcnt == 7){
-								$value .= chr($secureValue);
-								$secureValue = 0;
-								$bitcnt = 0;
-							}else{
-								++$bitcnt;
-							}
-							++$drop;
-						}else{
-							$drop += 2;
-						}
-					}
-				}
-			}
-			$output .= substr($value, 0, min($length - strlen($output), $length));
-			unset($value);
-			++$rounds;
+		$raw_output = random_bytes($length);
+		if ($raw) {
+			return $raw_output;
+		} else {
+			return bin2hex($raw_output);
 		}
-		$lastRandom = hash("sha512", $lastRandom, true);
-
-		return $raw === false ? bin2hex($output) : $output;
 	}
 
 	/*

--- a/src/pocketmine/wizard/Installer.php
+++ b/src/pocketmine/wizard/Installer.php
@@ -217,7 +217,7 @@ LICENSE;
 		echo "[?] " . $this->lang->rcon_enable . " (y/N): ";
 		if(strtolower($this->getInput("n")) === "y"){
 			$config->set("enable-rcon", true);
-			$password = substr(base64_encode(@Utils::getRandomBytes(20, false)), 3, 10);
+			$password = substr(base64_encode(random_bytes(20)), 3, 10);
 			$config->set("rcon.password", $password);
 			echo "[*] " . $this->lang->rcon_password . ": " . $password . "\n";
 		}else{


### PR DESCRIPTION
### Description

This PR changes all usages of `Utils::getRandomBytes()` to the builtin function `random_bytes()`. `Utils::getRandomBytes()` has been kept, but is deprecated and simply wraps `random_bytes()`.

### Reason to modify

* The existing function is poor-quality, mixing in only bad sources of entropy.
* Most of the "secure" random sources used read from the same ultimate source (/dev/urandom on Linux, macOS, and the BSDs), and the "weak" sources are extremely poor-quality.
* PHP 7 has a function to return cryptographically-secure random bytes, so the mess of code is not needed since we're using PHP 7.
* No calls are made for secure random bytes, ever.

### Tests & Reviews

I have tested the code and it works.