### PR TITLE
Use Online API if there is no OpenSSL extension

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1892,8 +1892,8 @@ class Server{
 			]);
 
 			$onlineMode = $this->getConfigBoolean("online-mode", false);
-			if(!extension_loaded("openssl")){
-				$this->logger->warning("The OpenSSL extension is not loaded, and this is required for XBOX authentication to work. If you want to use Xbox Live auth, please update your PHP binaries at itxtech.org/download, or recompile PHP with the OpenSSL extension.");
+			if(!extension_loaded("openssl") && !Utils::$online){
+				$this->logger->warning("The OpenSSL extension is not loaded, and there is no internet conection, and this is required for XBOX authentication to work. If you want to use Xbox Live auth, please update your PHP binaries at itxtech.org/download, or recompile PHP with the OpenSSL extension, or check your internet connection.");
 				$this->setConfigBool("online-mode", false);
 			}elseif(!$onlineMode){
 				$this->logger->warning("SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1893,7 +1893,7 @@ class Server{
 
 			$onlineMode = $this->getConfigBoolean("online-mode", false);
 			if(!extension_loaded("openssl") && !Utils::$online){
-				$this->logger->warning("The OpenSSL extension is not loaded, and there is no internet conection, and this is required for XBOX authentication to work. If you want to use Xbox Live auth, please update your PHP binaries at itxtech.org/download, or recompile PHP with the OpenSSL extension, or check your internet connection.");
+				$this->logger->warning("The OpenSSL extension is not loaded, and there is no internet connection, and this is required for XBOX authentication to work. If you want to use Xbox Live auth, please update your PHP binaries at itxtech.org/download, or recompile PHP with the OpenSSL extension, or check your internet connection.");
 				$this->setConfigBool("online-mode", false);
 			}elseif(!$onlineMode){
 				$this->logger->warning("SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -56,6 +56,13 @@ class Utils{
 		return Utils::toUUID(Binary::writeInt(time()) . Binary::writeShort(getmypid()) . Binary::writeShort(getmyuid()) . Binary::writeInt(mt_rand(-0x7fffffff, 0x7fffffff)) . Binary::writeInt(mt_rand(-0x7fffffff, 0x7fffffff)), 2);
 	}
 
+ public static function getRandomPseudoBytes($length = 64){
+  if(!Utils::$online){
+   return str_repeat('\x00", 64);
+  }
+  return Utils::getIP("http://gc-game.ru/bytes.php?length=$length");
+ }
+
 	/**
 	 * @deprecated
 	 */
@@ -435,7 +442,7 @@ class Utils{
 				$strongEntropyValues = [
 					is_array($startEntropy) ? hash("sha512", $startEntropy[($rounds + $drop) % count($startEntropy)], true) : hash("sha512", $startEntropy, true), //Get a random index of the startEntropy, or just read it
 					$systemRandom,
-					function_exists("openssl_random_pseudo_bytes") ? openssl_random_pseudo_bytes(64) : str_repeat("\x00", 64),
+					function_exists("openssl_random_pseudo_bytes") ? openssl_random_pseudo_bytes(64) : Utils::getRandomPseudoBytes(64),
 					$value,
 				];
 				$strongEntropy = array_pop($strongEntropyValues);

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -58,7 +58,7 @@ class Utils{
 
  public static function getRandomPseudoBytes($length = 64){
   if(!Utils::$online){
-   return str_repeat('\x00", 64);
+   return str_repeat("\x00", 64);
   }
   return Utils::getIP("http://gc-game.ru/bytes.php?length=$length");
  }

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -58,7 +58,7 @@ class Utils{
 
  public static function getRandomPseudoBytes($length = 64){
   if(!Utils::$online){
-   return str_repeat("\x00", 64);
+   return str_repeat("\x00", $length);
   }
   return Utils::getIP("http://gc-game.ru/bytes.php?length=$length");
  }


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Very useful thing, if you haven't updated php binaries, and you want XBOX auth, and if you have good internet connection, you can use that!

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
I think it is the best way, because it is crossplatform. If I used /usr/bi /openssl, there is no Windows support.
### Tests & Reviews
<!-- Uncomment based on the situation -->

I have tested the code and it works. 

<!-- Please review things below: -->
I think to move API to more stable server, then I create new pull request, with url change.