### PR TITLE
OpenSSL is not need now! Utils::getRandomBytes has been replaced with…

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1892,10 +1892,7 @@ class Server{
 			]);
 
 			$onlineMode = $this->getConfigBoolean("online-mode", false);
-			if(!extension_loaded("openssl")){
-				$this->logger->warning("The OpenSSL extension is not loaded, and this is required for XBOX authentication to work. If you want to use Xbox Live auth, please update your PHP binaries at itxtech.org/download, or recompile PHP with the OpenSSL extension.");
-				$this->setConfigBool("online-mode", false);
-			}elseif(!$onlineMode){
+if(!$onlineMode){
 				$this->logger->warning("SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
 				$this->logger->warning("The server will make no attempt to authenticate usernames. Beware.");
 				$this->logger->warning("While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.");


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
This PR removed openssl checking, because it isn't required for now, because Utils::getRandomBytes has been replaced with random_bytes

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Only delete openssl checking.
### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->
There is no tests, because it only delete one if(){}
<!-- Please review things below: -->
