### PR TITLE
The $immediate parameter was added in Player

### DIFF
--- a/src/synapse/Player.php
+++ b/src/synapse/Player.php
@@ -270,8 +270,8 @@ class Player extends PMPlayer{
 		$this->uuid = $uuid;
 	}
 
-	public function dataPacket(DataPacket $packet, $needACK = false){
-		$this->interface->putPacket($this, $packet, $needACK);
+	public function dataPacket(DataPacket $packet, $immediate = false, $needACK = false){
+		$this->interface->putPacket($this, $packet, $needACK, $immediate);
 	}
 
 	public function directDataPacket(DataPacket $packet, $needACK = false){


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
The $immediate parameter was added in Player, but not modified in this class.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
This causes a warning since synapse\Player extends pocketmine\Player, and the parameters should match.

### Tests & Reviews
Yes, I have tested this and this fixes the warnings.

https://github.com/iTXTech/Genisys/blob/master/src/pocketmine/Player.php#L1152