### PR TITLE
Re-add InventoryTransactionEvent with slightly different implementation

### DIFF
--- a/src/pocketmine/event/inventory/InventoryTransactionEvent.php
+++ b/src/pocketmine/event/inventory/InventoryTransactionEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link   http://www.pocketmine.net/
+ *
+ *
+ */
+
+namespace pocketmine\event\inventory;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\Event;
+use pocketmine\inventory\TransactionQueue;
+
+/**
+ * Called when an inventory transaction queue starts execution. 
+ */
+
+class InventoryTransactionEvent extends Event implements Cancellable{
+
+	public static $handlerList = null;
+	
+	/** @var TransactionQueue */
+	private $transactionQueue;
+	
+	/**
+	 * @param TransactionQueue $ts
+	 */
+	public function __construct(TransactionQueue $transactionQueue){
+		$this->transactionQueue = $transactionQueue;
+	}
+
+	/**
+	 * @deprecated
+	 * @return TransactionQueue
+	 */
+	public function getTransaction(){
+		return $this->transactionQueue;
+	}
+
+	/**
+	 * @return TransactionQueue
+	 */
+	public function getQueue(){
+		return $this->transactionQueue;
+	}
+}


### PR DESCRIPTION
### Description
New implementation of InventoryTransactionEvent. Fix plugin crashes.

**Please note: the reason this was removed in the first place was because it's inaccurate. With Win10 in the mix, slot changes cannot be paired.** This event will now be called when the player's transaction queue starts being processed. Cancelling this event will prevent queue execution.


### Reason to modify
Fix plugin crashes and provide a measure of control for plugins over the new inventory transaction system. This is not an ideal way to do it, but it's the best that can be done for now.

### Tests & Reviews
I have tested functionality and found no faults. However, I have not tested this with a plugin that uses the old-style event. Please test and review.