### PR TITLE
Improve deprecated methods

### DIFF
--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -99,7 +99,10 @@ class PlayerInventory extends BaseInventory{
 	 * Changes the linkage of the specified hotbar slot. This should never be done unless it is requested by the client.
 	 */
 	public function setHotbarSlotIndex($index, $slot){
-		trigger_error("Do not attempt to change hotbar links in plugins!", E_USER_DEPRECATED);
+		$i1 = $this->getItem($index);
+		$i2 = $this->getItem($slot);
+		$this->setItem($index, $i2);
+		$this->setItem($slot, $i1);
 	}
 
 	/**
@@ -212,6 +215,7 @@ class PlayerInventory extends BaseInventory{
 	 * @param int $slot
 	 */
 	public function setHeldItemSlot($slot){
+		$this->setHotbarSlotIndex($this->getHeldItemSlot(), $slot);
 	}
 
 	/**


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Some old plugins uses setHotbarSlotIndex or setHeldItemSlot.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
To work old plugins.
### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->
After W10 update, first 9 inventory slots automaticly at hotbar. If plugin want to change it, item in $slot moved to hotbar slot, and item in that slot has been moved to $slot. Same in setHeldItemSlot.
<!-- Please review things below: -->

