### PR TITLE
Fix the case of characters ( XBOX -> Xbox )

### DIFF
--- a/src/pocketmine/lang/locale/eng.ini
+++ b/src/pocketmine/lang/locale/eng.ini
@@ -15,7 +15,7 @@ chat.type.announcement=[{%0}] {%1}
 chat.type.admin=[{%0}: {%1}]
 chat.type.achievement={%0} has just earned the achievement {%1}
 
-disconnectionScreen.notAuthenticated=XBOX login required
+disconnectionScreen.notAuthenticated=Xbox login required
 disconnectionScreen.outdatedClient=Outdated client!
 disconnectionScreen.outdatedServer=Outdated server!
 disconnectionScreen.serverFull=Server is full!

--- a/src/pocketmine/lang/locale/jpn.ini
+++ b/src/pocketmine/lang/locale/jpn.ini
@@ -15,7 +15,7 @@ chat.type.announcement=[{%0}] {%1}
 chat.type.admin=[{%0}: {%1}]
 chat.type.achievement={%0}は{%1}の実績を手に入れました
 
-disconnectionScreen.notAuthenticated=XBOXでのログインが必要です
+disconnectionScreen.notAuthenticated=Xboxでのログインが必要です
 disconnectionScreen.outdatedClient=古いクライアントです！
 disconnectionScreen.outdatedServer=古いサーバーです！
 disconnectionScreen.serverFull=サーバーは満員です！

--- a/src/pocketmine/lang/locale/rus.ini
+++ b/src/pocketmine/lang/locale/rus.ini
@@ -15,7 +15,7 @@ chat.type.announcement=[{%0}] {%1}
 chat.type.admin=[{%0}: {%1}]
 chat.type.achievement=Игрок {%0} получил достижение {%1}!
 
-disconnectionScreen.notAuthenticated=Требуется авторизация в XBOX Live!
+disconnectionScreen.notAuthenticated=Требуется авторизация в Xbox!
 disconnectionScreen.outdatedClient=Устаревший клиент!
 disconnectionScreen.outdatedServer=Устаревший сервер!
 disconnectionScreen.serverFull=Сервер переполнен!


### PR DESCRIPTION
### Description
Fix the case of characters. And removed "Live" from Russian lang file.


### Reason to modify
- See [xbox.com](xbox.com) for correct case of "Xbox".
- This PR is to follow the correct case on [xbox.com](xbox.com).