### PR TITLE
Rewrite deprecated methods for new PlayerInventory system

### DIFF
--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -99,7 +99,10 @@ class PlayerInventory extends BaseInventory{
 	 * Changes the linkage of the specified hotbar slot. This should never be done unless it is requested by the client.
 	 */
 	public function setHotbarSlotIndex($index, $slot){
-		trigger_error("Do not attempt to change hotbar links in plugins!", E_USER_DEPRECATED);
+		$i1 = $this->getItem($index);
+		$i2 = $this->getItem($slot);
+		$this->setItem($index, $i2);
+		$this->setItem($slot, $i1);
 	}
 
 	/**
@@ -212,6 +215,7 @@ class PlayerInventory extends BaseInventory{
 	 * @param int $slot
 	 */
 	public function setHeldItemSlot($slot){
+		$this->setHotbarSlotIndex($this->getHeldItemSlot(), $slot);
 	}
 
 	/**

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -94,10 +94,11 @@ class PlayerInventory extends BaseInventory{
 	}
 
 	/**
-	 * @deprecated
+	 * @param int $index
+	 * @param int $slot
 	 *
-	 * Changes the linkage of the specified hotbar slot. This should never be done unless it is requested by the client.
-	 */
+		* Move item to hotbar slot. Compatible with old method
+ */
 	public function setHotbarSlotIndex($index, $slot){
 		$i1 = $this->getItem($index);
 		$i2 = $this->getItem($slot);
@@ -211,7 +212,6 @@ class PlayerInventory extends BaseInventory{
 	}
 
 	/**
-	 * @deprecated
 	 * @param int $slot
 	 */
 	public function setHeldItemSlot($slot){

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -97,8 +97,8 @@ class PlayerInventory extends BaseInventory{
 	 * @param int $index
 	 * @param int $slot
 	 *
-		* Move item to hotbar slot. Compatible with old method
- */
+	 * Move item to hotbar slot. Compatible with old method
+	 */
 	public function setHotbarSlotIndex($index, $slot){
 		$i1 = $this->getItem($index);
 		$i2 = $this->getItem($slot);


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
After Windows 10 update, PlayerInventory doesn't allow to change it. But not everyone will rewrite the plugins. There is alternative to change hotbar(COMPATIBLE WITH WINDOWS 10).

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Some people will not update their plugins, there is alternative to change hotbar(and held item).
### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->
It must works on every platform, because after Inventory fix, all hotbar slots automaticly sets to first 9 slots of inventory. My code uses this feature, and change this slots instead remapping hotbar. Please view the code before closing this PR.
<!-- Please review things below: -->
