### PR TITLE
Fix #1744 - disallow teleporting sleeping players

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4274,7 +4274,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 * @return bool
 	 */
 	public function teleport(Vector3 $pos, $yaw = null, $pitch = null){
-		if(!$this->isOnline()){
+		if(!$this->isOnline() or $this->isSleeping()){
 			return false;
 		}
 

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -93,6 +93,10 @@ class TeleportCommand extends VanillaCommand{
 
 			return true;
 		}elseif($target->getLevel() !== null){
+			if($target->isSleeping()){
+				$sender->sendMessage(TextFormat::RED . "Cannot teleport a sleeping player!");
+				return true;
+			}
 			if(count($args) === 4 or count($args) === 6){
 				$pos = 1;
 			}else{


### PR DESCRIPTION
### Description
Disallow teleporting sleeping players. Fix #1744 

### Reason to modify
Fix #1744 

### Tests & Reviews
This has not been tested, but it should fix the problem. Please test and review.