### PR TITLE
Fix #1598

### DIFF
--- a/src/raklib/server/Session.php
+++ b/src/raklib/server/Session.php
@@ -533,8 +533,7 @@ class Session{
 	}
 
 	public function close(){
-		$data = "\x00\x00\x08\x15";
-		$this->addEncapsulatedToQueue(EncapsulatedPacket::fromBinary($data), RakLib::PRIORITY_IMMEDIATE); //CLIENT_DISCONNECT packet 0x15
+		$this->addEncapsulatedToQueue(EncapsulatedPacket::fromBinary("\x60\x00\x08\x00\x00\x00\x00\x00\x00\x00\x15")); //CLIENT_DISCONNECT packet 0x15
 		$this->sessionManager = null;
 	}
 }


### PR DESCRIPTION
This bug is really annoying for me so i started looking into it and when i found a fix i decided to create this pr to help this project :smile: so, i'm really sorry @dktapps if i broke things in the past, i was just trying to help. Yes was my fault because PRs were fast coded and not well tested but it's also yours because you accepted them :joy: :stuck_out_tongue_winking_eye: so , don't hate me :sweat_smile: :kissing_heart::kissing_heart:

I made many tests analyzing packets in localhost using wireshark (if you don't trust me make them) here are some screenshoots:

In this screen (test1):
- n°21 is the 0x05 (DisconnectPacket)
- n°22 is the 0x15 (ClientDisconnectPacket)
- n°23-24 are the acks
![test1](https://cloud.githubusercontent.com/assets/16593861/17873150/2ca487b0-68c4-11e6-87c1-b779e0ee8b1f.png)
In this screen (test2):
- n°217 is the 0x05 (DisconnectPacket)
- n°218 is the 0x15 (ClientDisconnectPacket)
- n°219 are the acks in a single packet
![test2](https://cloud.githubusercontent.com/assets/16593861/17873151/30597a96-68c4-11e6-9ed2-dc72561441fc.png)
In this screen (test2_1):
- Is the same as test2 (it is test2) but i'm showing the 0x15
![test2_1](https://cloud.githubusercontent.com/assets/16593861/17873160/3bc725b8-68c4-11e6-9dbf-be739651e6d3.png)
In this screen (test3):
- n°204 is the 0x05 (DisconnectPacket)
- n°205 is the 0x15 (ClientDisconnectPacket)
- n°206 are the acks in a single packet
![test3](https://cloud.githubusercontent.com/assets/16593861/17873163/3e70c9ae-68c4-11e6-8553-891160d405b9.png)

**Yes i lost test4 don't ask me how but if you want to know: was the same as test3-2**

In this screen (test5):
- n°77 is the 0x05 (DisconnectPacket)
- n°78 is the 0x15 (ClientDisconnectPacket)
- n°79-80 are the acks
![test5](https://cloud.githubusercontent.com/assets/16593861/17873166/40322684-68c4-11e6-9b70-d5c3e03c3560.png)
In this screen (test6):
- n°232 is the 0x05 (DisconnectPacket)
- n°233 is the 0x05 ack
- n°234 is the 0x15 (ClientDisconnectPacket)
- n°235 is the 0x15 ack
![test6](https://cloud.githubusercontent.com/assets/16593861/17873179/4af6fdf6-68c4-11e6-9604-934ca9ca7316.png)

What i can notice from the above:

- Since it is on localhost both packets (0x05 and 0x15) are sent around at the same moment and also received at around the same moment (see "time column")

We don't know how the client will handle this, maybe the 0x15 closes the connection before because it's received before since is smaller? maybe the last packet received will be relevant and the 0x15 is ignored (since both acks are sent) ? someone knows? I don't. But i'm sure there is a reason if test6 worked.

Here i analyzed how mcpe handles it between 2 clients on localhost "quitting to title" from the "hoster client" . I can't find a way to analyze 0x05, here is the 0x15:
![clients](https://cloud.githubusercontent.com/assets/16593861/17874070/aa5bfb16-68c9-11e6-9ca0-7554d2c84023.png)
It isn't UNRELIABLE (0x00 = 0b0000 0000 >> 5 = 0), it is RELIABLE_ORDERED (0x60 = 0b0110 0000 >> 5 = 3)

So, why in this commit i changed it from UNRELIABLE to RELIABLE_ORDERED ?<br>
Not because i would like to copy the client without reason but because of the reasons you can find in the commit description.

>There was a "race" between the DisconnectPacket (0x05) and the ClientDisconnectPacket (0x15) because both were sent about at the same moment. This commit will change how the 0x15 is sent: as a RELIABLE_ORDERED . In this way the client will receive the 0x05 before since it is already sent as an UNRELIABLE (there are no queues both client&server side and it is sent immediatly) . The 0x15 will be sent but ignored by the client because the client will close the connection after the 0x05 but to avoid breaking things i left it.

In this screen (fix1):
- n°9 is the 0x05 (DisconnectPacket)
- n°10 is the 0x05 ack
- n°11 is the 0x15 (ClientDisconnectPacket)
![fix1](https://cloud.githubusercontent.com/assets/16593861/17873183/4f7c6ed8-68c4-11e6-83db-b4ed2d5e35cd.png)
In this screen (fix2):
- Showing the 0x15, seems like it is ignored, there is not ack for it
![fix2](https://cloud.githubusercontent.com/assets/16593861/17873184/51817fd4-68c4-11e6-96b6-bef6c194363f.png)

Is this the best way to fix this bug?<br>
Idk there can be many ways to fix this the important thing is that i explained what i think about it, maybe my explaination will be useful to someone who want to fix it in a better way.

For example, it will make sence replacing the way 0x05 is sent: send it as RELIABLE_ORDERED and there will be no order problem, yes it will be slower but, hey the majority of the packets sent by the server are RELIABLE_ORDERED. i didn't change this to avoid breaking things (it will not break things but players will not notice the difference so i tought: keep it as is there won't be a big difference changing it) (for this to be true also 0x15 need to be send as RELIABLE_ORDERED too otherwise it will arrive before)

### Tests & Reviews
Well, i tested it a lot this time (really) and it's working but if it will not, dont't kill me :persevere:, thanks to all the DEVs for this good project

###### If i wrote something wrong it's because it's 01:28am here, goodnight :sleeping: