### PR TITLE
Fix #1744 and players levitating in beds

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1232,7 +1232,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 
 		$this->sleeping = clone $pos;
-		$this->teleport(new Position($pos->x + 0.5, $pos->y - 1, $pos->z + 0.5, $this->level));
 
 		$this->setDataProperty(self::DATA_PLAYER_BED_POSITION, self::DATA_TYPE_POS, [$pos->x, $pos->y, $pos->z]);
 		$this->setDataFlag(self::DATA_PLAYER_FLAGS, self::DATA_PLAYER_FLAG_SLEEP, true);
@@ -1918,7 +1917,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					}
 				}
 			}
-			$this->processMovement($tickDiff);
+			if(!$this->isSleeping()){
+				$this->processMovement($tickDiff);
+			}
 
 			if(!$this->isSpectator()) $this->entityBaseTick($tickDiff);
 
@@ -4300,6 +4301,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->resetFallDistance();
 			$this->nextChunkOrderRun = 0;
 			$this->newPosition = null;
+			$this->stopSleep();
 			return true;
 		}
 		return false;


### PR DESCRIPTION
### Description
Fix #1744 - teleporting a sleeping player causes them to remain in the sleeping position
Fix players floating above beds from another player's point of view


### Reason to modify
Levitation - do not process movement changes for players in beds
Teleporting - wake up players when teleporting them.
Removed a broken hack which was a previous attempt to fix levitation.

### Tests & Reviews
I have tested the following:
- Sleeping on a bed and watching from another player's point of view
- Teleporting sleeping players, both as the player in the bed and another player
- Ensuring that sleep still fast-forwards time as observed by @ZedCee 