### PR TITLE
Add Korean translation

### DIFF
--- a/src/pocketmine/lang/Installer/kor.ini
+++ b/src/pocketmine/lang/Installer/kor.ini
@@ -1,0 +1,51 @@
+language_has_been_selected = 한국어가 언어로 선택되었습니다.
+skip_installer = 설치 마법사를 건너뛰겠습니까?
+
+welcome_to_pocketmine = PocketMine-MP에 오신 것을 환영합니다!\n서버 설치를 시작하기 전, 약관에 동의해야 합니다. \nPocketMine-MP는 GNU 약소 일반 공중 사용 허가서(LGPL) 하에 배포되고 있습니다. \n이 폴더에서 약관을 읽을 수 있습니다.
+accept_license = 약관에 동의하십니까?
+you_have_to_accept_the_license = GNU 약소 일반 공중 사용 허가서(LGPL)에 동의하셔야 PocketMine-MP를 사용할 수 있습니다.
+
+setting_up_server_now = 서버 설정을 시작합니다.
+default_values_info = 기본값을 수정하고 싶지 않으면, 엔터를 누르시기 바랍니다.
+server_properties = 이 설정들은 server.properties 파일에서 세부적으로 변경이 가능합니다.
+
+name_your_server = 당신의 서버 이름을 입력하시기 바랍니다.
+port_warning = 만약 당신이 서버를 처음 설정한다면 포트 값을 변경하지 마세요.
+server_port = 서버 포트
+invalid_port = 서버 포트가 잘못 입력되었습니다.
+online_mode_info = 온라인 모드에서는 서버가 사용자를 XBOX를 사용해서만 로그인하도록 합니다.\n외부 서버를 여는 경우 온라인 모드를 활성화 하는 것이 좋습니다.
+online_mode = 온라인 모드를 활성화 하시겠습니까?
+ram_warning = RAM 값은 PocketMine-MP에 할당할 메모리의 크기입니다. 128~256MB를 권장합니다.
+server_ram = 서버의 램(RAM) (MB)
+gamemode_info = 크리에이티브 (1) 또는 서바이벌 (0) 게임모드 중 하나를 고르세요.
+default_gamemode = 기본 게임 모드
+max_players = 최대 동시접속 인원 수
+spawn_protection_info = 스폰 보호는 OP를 제외한 유저들이 스폰 지역 근처에서 블럭을 놓거나 부수는 것을 방지합니다.
+spawn_protection = 스폰 지역 보호를 사용하겠습니까?
+level_name = 레벨의 이름을 설정하시기 바랍니다.
+level_type = 레벨의 유형을 설정하시기 바랍니다.
+invalid_level_type = 레벨 유형이 잘못 입력되었습니다.
+announce_player_achievements = 플레이어가 도전 과제를 달성했을때 알리시겠습니까?
+
+op_info = OP는 서버 관리자를 뜻합니다. OP는 일반 플레이어보다 훨씬 많은 명령어들을 사용할 수 있습니다
+op_who = OP 권한을 줄 플레이어 이름(예: 당신의 닉네임)
+op_warning = 또는 이후에 /op <플레이어 이름> 을 입력해 그 유저에게 OP 권한을 줄 수도 있습니다
+whitelist_info = 화이트리스트를 사용하면 허용된 플레이어들만 서버에 접속할 수 있습니다.
+whitelist_enable = 화이트리스트를 사용하겠습니까?
+whitelist_warning = 당신은 접속을 허용할 플레이어들의 이름을 적어야 합니다
+
+query_warning1 = 쿼리 (Query)는 당신의 서버와 현재 접속한 플레이어들의 정보를 알 수 있게 해주는 여러가지 기능이 담긴 프로토콜입니다.
+query_warning2 = 쿼리를 사용하지 않으면, 당신은 서버 리스트를 사용할 수 없게 됩니다.
+query_disable = 쿼리를 사용하지 않겠습니까?
+rcon_info = RCON은 비밀 번호를 사용하여 서버 명령창에 원격으로 접속할 수 있는 프로토콜입니다.
+rcon_enable = RCON을 사용하시겠습니까?
+rcon_password = RCON 비밀번호 설정 (나중에 server.properties 에서 변경이 가능합니다.)
+usage_info = 익명 사용 통계 전송을 허용하면 PocketMine-MP가 세계의 서버 상황과 플러그인들을 통계화하는 데 사용할 수 있습니다. 당신은 stats.pocketmine.net에서 이를 확인할 수 있습니다
+usage_disable = 익명 사용 통계 전송을 사용하지 않으시겠습니까?
+ip_get = 내/외부 IP 주소 얻기
+ip_warning = 당신의 외부 IP는 {{EXTERNAL_IP}}입니다. 당신의 내부 IP {{INTERNAL_IP}}로 포트포워딩이 필요할 수 있습니다
+ip_confirm = 신중하게 확인하세요. 만약 포트포워딩이 필요하지만 하지 않을 경우 외부에서 플레이어들이 접속할 수 없게 됩니다. [계속 하시려면 엔터를 누르세요]
+
+you_have_finished = PocketMine-MP의 설치가 모두 완료되었습니다.
+pocketmine_will_start = PocketMine-MP 서버를 구동합니다. /help로 사용 가능한 모든 명령어의 목록을 보시기 바랍니다.
+pocketmine_plugins = 플러그인 저장소에서 새로운 기능을 추가하세요. 새로운 기능, 미니게임을 추가하거나 고급 기능으로 당신의 서버를 보호할 수 있습니다

--- a/src/pocketmine/lang/locale/kor.ini
+++ b/src/pocketmine/lang/locale/kor.ini
@@ -1,0 +1,406 @@
+# Language file compatible with Minecraft: Pocket Edition identifiers
+#
+# A message doesn't need to be there to be shown correctly on the client.
+# Only messages shown in PocketMine itself need to be here
+
+language.name="한국어 | Johnmacrocraft가 번역"
+language.selected={%0} ({%1})(이)가 기본 언어로 설정되었습니다.
+
+multiplayer.player.joined={%0} 님이 게임에 접속했습니다
+multiplayer.player.left={%0}님이 게임에서 나갔습니다
+
+chat.type.text=<{%0}> {%1}
+chat.type.emote=* {%0} {%1}
+chat.type.announcement=[{%0}] {%1}
+chat.type.admin=[{%0}: {%1}]
+chat.type.achievement={%0}님이 업적 {%1}을(를) 달성했습니다
+
+disconnectionScreen.notAuthenticated=Xbox 로그인이 필요합니다!
+disconnectionScreen.outdatedClient=오래된 클라이언트입니다!
+disconnectionScreen.outdatedServer=오래된 서버입니다!
+disconnectionScreen.serverFull=서버 최대 인원 수를 초과하였습니다.
+disconnectionScreen.noReason=서버와의 연결이 끊어졌습니다.
+disconnectionScreen.invalidSkin=올바르지 않거나 지원되지 않는 스킨입니다.
+disconnectionScreen.invalidName=올바르지 않거나 잘못된 형식의 이름입니다!
+
+death.fell.accident.generic={%0} 님이 높은 곳에서 떨어졌습니다
+death.attack.inFire={%0} 님이 불에 타 죽었습니다
+death.attack.onFire={%0} 님이 불에 타서 죽었습니다
+death.attack.lava={%0} 님이 용암에 빠져 죽었습니다
+death.attack.inWall={%0} 님이 벽에 끼어 질식사했습니다
+death.attack.drown={%0} 님이 익사했습니다
+death.attack.cactus={%0} 님이 가시에 찔려서 사망했습니다
+death.attack.generic={%0} 님이 사망했습니다
+death.attack.explosion={%0}님이 폭발로 인해 사망하셨습니다.
+death.attack.explosion.player={%0} 님이 {%1} 님에 의해 폭사했습니다
+death.attack.magic={%0}님이 마법에 의해 죽었습니다
+death.attack.wither={%0} 님이 말라서 죽었습니다
+death.attack.mob={%0} 님이 {%1} 에게 살해당했습니다
+death.attack.player={%0} 님이 {%1} 에게 살해당했습니다
+death.attack.player.item={%0} 님이 {%1} 님에게 {%2} (으)로 살해당했습니다
+death.attack.arrow={%0} 님이 {%1} 님에게 저격당했습니다
+death.attack.arrow.item={%0}님이 {%1}님에게 {%2}(으)로 저격당했습니다.
+death.attack.fall={%0} 님이 너무 높은 곳에서 떨어져 사망했습니다
+death.attack.outOfWorld={%0} 님이 세계 밖으로 떨어져서 사망했습니다
+
+gameMode.survival=서바이벌 모드
+gameMode.creative=크리에이티브 모드
+gameMode.adventure=모험 모드
+gameMode.spectator=관전 모드
+gameMode.changed=게임 모드가 변경되었습니다
+
+potion.moveSpeed=신속
+potion.moveSlowdown=구속
+potion.digSpeed=성급함
+potion.digSlowDown=피로
+potion.damageBoost=힘
+potion.heal=즉시 회복
+potion.harm=즉시 데미지
+potion.jump=점프 강화
+potion.confusion=멀미
+potion.regeneration=재생
+potion.resistance=저항
+potion.fireResistance=화염 저항
+potion.waterBreathing=수중 호흡
+potion.invisibility=투명화
+potion.blindness=실명
+potion.nightVision=야간 투시
+potion.hunger=허기
+potion.weakness=나약함
+potion.poison=독
+potion.wither=위더
+potion.healthBoost=체력 강화
+potion.absorption=흡수
+potion.saturation=포화
+
+commands.generic.exception=이 명령을 수행하는 동안 알 수 없는 오류가 발생했습니다
+commands.generic.permission=이 명령을 사용할 수 있는 권한이 없습니다
+commands.generic.notFound=알 수 없는 명령입니다. /help 로 명령어 목록을 보세요
+commands.generic.player.notFound=플레이어를 찾을 수 없습니다
+commands.generic.usage=사용법: {%0}
+commands.generic.level=level-name
+commands.generic.seed=seed-name
+commands.generic.name=name
+commands.generic.generator=generator-name
+commands.generic.opt.missing=Missing required properties, please confirm and re-enter.
+commands.generic.runingame=게임안에서 이 명령어를 사용해 주세요.
+
+commands.time.added=시간을 {%0}만큼 추가하였습니다
+commands.time.set={%0}으로 시간을 설정하였습니다
+commands.time.query=현재 시간은 {%0}입니다
+
+commands.me.usage=/me <행동>
+
+commands.give.item.notFound={%0}의 이름을 가진 아이템이 없습니다
+commands.give.success={%2}님에게 {%0}을(를) {%1}개 주었습니다
+commands.give.tagError=데이터 태그 분석 실패: {%0}
+
+commands.effect.usage=/effect <유저명> <효과명> [초] [증폭] [입자 숨김] 또는 /effect <유저명> clear (효과 없애기)
+commands.effect.notFound=효과 ID {%0}는 존재하지 않습니다
+commands.effect.success=효과 {%0} (ID {%1} * {%2})를 {%3}에게 {%4}초간 주었습니다
+commands.effect.success.removed= {%1}님에게서 효과 {%0}을(를) 제거하였습니다.
+commands.effect.success.removed.all={%0} 님의 모든 효과를 제거하였습니다.
+commands.effect.failure.notActive={%1}님에게 {%0}효과를 뺏을 수 없습니다, 어떤 효과도 걸려있지 않습니다.
+commands.effect.failure.notActive.all={%0}님에게 어떠한 효과도 걸려있지 않기 때문에 효과를 뺏을 수 없습니다
+
+commands.enchant.noItem=대상이 아이템을 들고 있지 않아 마법을 부여 할 수 없습니다
+commands.enchant.notFound=ID가 {%0} 인 마법 부여 효과는 없습니다
+commands.enchant.success=마법 부여를 완료하였습니다
+commands.enchant.cantEnchant=선택한 마법 부여는 대상 아이템에 추가될 수 없습니다
+commands.enchant.usage=/enchant <플레이어> <마법 부여 ID> [레벨]
+commands.particle.success={%0}효과를 {%1} 초간 지속합니다
+commands.particle.notFound={%0}는 알 수 없는 효과명입니다
+commands.players.usage=/list
+commands.players.list=현재 {%0}/{%1} 명이 접속 중입니다:
+commands.kill.successful={%0}님을 죽였습니다
+commands.banlist.ips=총 %d개의 차단된 IP 주소들이 있습니다:
+commands.banlist.players=총 {%0}명의 차단된 플레이어가 있습니다:
+commands.banlist.cids=총 {%0}개의 차단된 CID들이 있습니다:
+commands.banlist.usage=/banlist [아이피|플레이어 이름]
+commands.defaultgamemode.usage=/defaultgamemode <게임 모드>
+commands.defaultgamemode.success=기본 게임모드가 {%0}로 변경되었습니다.
+
+commands.op.success={%0}을 OP로 설정하였습니다
+commands.op.usage=/op <플레이어>
+
+commands.deop.success={%0}님의 OP 권한을 박탈하였습니다
+commands.deop.usage=/deop <플레이어>
+
+commands.say.usage=/say <메시지 ...>
+
+commands.seed.usage=/seed
+commands.seed.success=시드: {%0}
+
+commands.bancidbyname.success=플레이어 {%0}님의 CID를 차단하였습니다
+commands.bancidbyname.usage=/bancidbyname <플레이어 이름>
+
+commands.bancid.success=CID 차단: {%0}
+commands.bancid.usage=/bancid <클라이언트 ID>
+
+commands.unbancid.usage=/pardoncid <클라이언트 ID>
+commands.unbancid.success=CID {%0}의 차단을 해제하였습니다
+
+commands.ban.success=플레이어 {%0}를 차단하였습니다
+commands.ban.usage=/ban <이름> [사유 ...]
+
+commands.unban.success=플레이어 {%0}님을 차단 해제하였습니다
+commands.unban.usage=/pardon <차단 해제할 플레이어 이름>
+
+commands.banip.invalid=잘못된 IP 주소이거나 현재 접속해있지 않은 플레이어입니다
+commands.banip.success=IP 주소 {%0}을(를) 차단하였습니다
+commands.banip.success.players={%1}님의 IP 주소 {%0}을(를) 차단하였습니다
+commands.banip.usage=/ban-ip <IP 주소|이름> [사유 ...]
+
+commands.unbanip.invalid=잘못된 IP 주소를 입력하였습니다
+commands.unbanip.success=IP 주소 {%0}의 차단을 해제하였습니다
+commands.unbanip.usage=/pardon-ip <IP 주소>
+
+commands.banipbyname.success=플레이어 {%0}님의 IP를 차단하였습니다
+commands.banipbyname.usage=/banipbyname <플레이어 이름>
+
+commands.save.usage=/save-all
+commands.save-on.usage=/save-on
+commands.save-off.usage=/save-off
+commands.save.enabled=월드 자동 저장 기능을 활성화하였습니다
+commands.save.disabled=월드 자동 저장 기능을 비활성화하였습니다
+commands.save.start=월드를 저장 중...
+commands.save.success=월드를 저장했습니다
+
+commands.setblock.usage=/setblock <x> <y> <z> <블럭 이름> [손상 정도]
+command.setblock.invalidBlock=잘못된 블럭 이름/ID입니다
+
+commands.stop.usage=/stop
+commands.stop.start=서버를 끄는 중입니다
+
+commands.kick.success={%0}을 게임에서 강제 퇴장시켰습니다
+commands.kick.success.reason={%0}님이 강제 퇴장당하셨습니다. (사유: {%1})
+commands.kick.usage=/kick <플레이어> [사유 ...]
+
+commands.tp.success={%0}을(를) {%1}(으)로 이동시켰습니다
+commands.tp.success.coordinates={%0}님을 X:{%1}, Y:{%2}, Z:{%3}(으)로 이동시켰습니다
+commands.tp.usage=/tp [이동시킬 플레이어] <도착 지점 플레이어> 또는 /tp [이동시킬 플레이어] <x> <y> <z> [<y-rot> <x-rot>]
+
+commands.whitelist.list=(보여진 {%1} 중) {%0}명의 화이트리스트 된 플레이어가 있습니다:
+commands.whitelist.enabled=화이트리스트 기능을 활성화하였습니다
+commands.whitelist.disabled=화이트리스트 기능을 비활성화하였습니다
+commands.whitelist.reloaded=화이트리스트를 재적재하였습니다.
+commands.whitelist.add.success={%0}님을 화이트리스트에 추가하였습니다
+commands.whitelist.add.usage=/whitelist add <플레이어>
+commands.whitelist.remove.success={%0}님을 화이트리스트에서 삭제하였습니다
+commands.whitelist.remove.usage=/whitelist remove <플레이어명>
+commands.whitelist.usage=/whitelist <on|off|list|add|remove|reload>
+
+commands.gamemode.success.self=자신의 게임 모드를 {%0}으로 설정하였습니다
+commands.gamemode.success.other={%0}님의 게임 모드를 {%1}로 설정했습니다
+commands.gamemode.usage=/gamemode <모드> [플레이어명]
+commands.help.header=--- 전체 페이지 {%1} 중 {%0}번째 페이지 (/help <페이지>) ---
+commands.help.usage=/help [페이지|명령어]
+commands.message.usage=/tell <플레이어> <비밀 메시지 ...>
+commands.message.sameTarget=자기 자신에게 비밀 메시지를 보낼 수 없습니다!
+commands.xp.usage=/xp <경험치 또는 경험치 레벨+L> <player>
+
+commands.difficulty.usage=/difficulty <새로운 난이도>
+commands.difficulty.success=게임 난이도를 {%0}(으)로 설정하였습니다
+
+commands.spawnpoint.usage=/spawnpoint [플레이어] [<x> <y> <z>]
+commands.spawnpoint.success={%0}의 스폰 위치를 ({%1}, {%2}, {%3})로 설정하였습니다
+commands.setworldspawn.usage=/setworldspawn [<x> <y> <z>]
+commands.setworldspawn.success=월드의 스폰 지점을 ({%0}, {%1}, {%2})로 설정하였습니다
+
+commands.summon.usage=/summon [엔티티] [<x> <y> <z>] [NBTTag]
+
+# -------------------- PocketMine language files, only for console --------------------
+pocketmine.data.playerNotFound=플레이어 "{%0}"님의 데이터를 찾지 못했습니다. 새 프로필을 생성합니다.
+pocketmine.data.playerCorrupted=플레이어 "{%0}"님의 데이터가 손상되었습니다. 새로운 프로필을 생성합니다.
+pocketmine.data.playerOld=플레이어 "{%0}"님의 데이터가 오래되었습니다. 프로파일을 업데이트합니다.
+pocketmine.data.saveError=플레이어 "{%0}"님의 데이터를 저장하지 못했습니다: {%1}
+pocketmine.level.notFound="{%0}" 월드를 찾지 못했습니다
+pocketmine.level.loadError=월드 "{%0}"를(을) 불러오지 못했습니다: {%1}
+pocketmine.level.generationError=월드 "{%0}"를(을) 생성하지 못했습니다: {%1}
+pocketmine.level.tickError="{%0}" 월드의 틱을 처리하지 못했습니다: {%1}
+pocketmine.level.chunkUnloadError=청크 언로드 중 오류가 발생했습니다: {%0}
+pocketmine.level.backgroundGeneration=월드 "{%0}"의 스폰 지형이 백그라운드에서 생성됩니다...
+pocketmine.level.defaultError=기본 월드를 찾을 수 없습니다 
+pocketmine.level.preparing=월드 "{%0}"를(을) 준비 중입니다...
+pocketmine.level.unloading=월드 "{%0}"를(을) 언로드 중입니다...
+pocketmine.server.start=마인크래프트: 포켓 에디션 (버전 {%0}용) 서버를 시작 중입니다...
+pocketmine.server.networkError=[Network] 인터페이스 {%0}가 {%1}로 인해 작동 중단되었습니다.
+pocketmine.server.networkStart=서버를 {%0}:{%1}에서 여는 중입니다
+pocketmine.server.info=이 서버는 {%0} (버전 {%1} "{%2}" (API {%3}))을 구동 중입니다
+
+pocketmine.server.info.extended.title=-----서버 정보-----
+pocketmine.server.info.extended1=이 서버는 {%0}{%1} (코드네임 "{%2}")을 구동 중입니다
+pocketmine.server.info.extended2=PHP 버전: {%0}
+pocketmine.server.info.extended3=API: {%0} (iTX API 버전 {%1})
+pocketmine.server.info.extended4=대상 클라이언트: Minecraft PE {%0} (프로토콜 버전 {%1})
+
+pocketmine.server.license={%0}는(은) LGPL 라이센스 하에서 배포됩니다
+pocketmine.server.tickOverload=서버 처리 속도가 느려졌습니다. 서버가 과부하되었는지 확인해주시기 바랍니다.
+pocketmine.server.startFinished=서버 구동 준비 완료! :D ({%0}초) 명령어 목록을 확인하시려면 "help" 또는 "?"를 입력해 주세요.
+pocketmine.server.defaultGameMode=기본 게임 모드: {%0}
+pocketmine.server.query.start=GS4 쿼리 리스너를 시작 중입니다
+pocketmine.server.query.info=쿼리 포트를 {%0}로 설정합니다
+pocketmine.server.query.running=쿼리 서버가 {%0}:{%1}에서 실행 중입니다
+
+pocketmine.command.alias.illegal=명령어 별칭 {%0}을 등록하지 못했습니다. 잘못된 문자를 포함하고 있습니다.
+pocketmine.command.alias.notFound=명령어 별칭 {%0}을 등록하지 못했습니다. 존재하지 않는 명령어를 포함합니다: {%1}
+pocketmine.command.exception=플러그인 {%1}에서 명령어 '{%0}'을 실행하는 중 예외가 발생했습니다: {%2}
+
+commands.cave.usage=/cave <angle of rotation> <length> <Branch Number> <strength> <X> <Y> <Z> <LevelName> | /cave getmypos
+commands.cave.info=Angle of rotation:{%0} Length:{%1} Branch Number:{%2} Strength:{%3}
+commands.cave.start=동굴을 생성하는 중, 잠시만 기다리세요
+commands.cave.success=동굴이 생성되었습니다
+
+pocketmine.command.plugins.description=서버에서 실행 중인 플러그인 목록을 불러옵니다.
+pocketmine.command.plugins.success=플러그인 목록 (전체 {%0}개): {%1}
+pocketmine.command.plugins.usage=/plugins
+
+pocketmine.command.reload.description=서버 설정과 플러그인을 다시 불러옵니다.
+pocketmine.command.reload.usage=/reload
+pocketmine.command.reload.reloading=서버를 다시 불러오는 중입니다...
+pocketmine.command.reload.reloaded=서버 설정을 다시 불러왔습니다.
+
+pocketmine.command.lvdat.description=맵의 속성을 변경합니다.
+pocketmine.command.lvdat.changed=has changed {%1} of level "{%0}", some change need to reboot your server.
+pocketmine.command.lvdat.fixname=fixname successfully for level "{%0}", some change need to reboot your server.
+pocketmine.command.lvdat.nofound=레벨 "{%0}"이 없거나 로드하지 못했습니다.
+pocketmine.command.lvdat.preset=Generator setting (preset)
+
+pocketmine.command.status.description=서버의 현재 상태를 확인합니다 (TPS 등)
+pocketmine.command.status.usage=/status
+
+pocketmine.command.status.title=서버 상태
+pocketmine.command.status.player=플레이어 count:
+pocketmine.command.status.days=일
+pocketmine.command.status.hours=시간
+pocketmine.command.status.minutes=분
+pocketmine.command.status.seconds=초
+pocketmine.command.status.uptime=작업 시간:
+pocketmine.command.status.AverageTPS=평균 TPS:
+pocketmine.command.status.CurrentTPS=현재 TPS:
+pocketmine.command.status.Networkupload=네트워크 업로드:
+pocketmine.command.status.Networkdownload=네트워크 다운로드:
+pocketmine.command.status.Threadcount=스레드 수:
+pocketmine.command.status.Mainmemory=메인 스레드 메모리;
+pocketmine.command.status.Totalmemory=총 메모리:
+pocketmine.command.status.Totalvirtualmemory=총 가상 메모리:
+pocketmine.command.status.Heapmemory=힙 메모리:
+pocketmine.command.status.Maxmemorysystem=최대 메모리 (시스템):
+pocketmine.command.status.Maxmemorymanager=최대 메모리 (관리자):
+pocketmine.command.status.World=월드
+pocketmine.command.status.chunks=청크,
+pocketmine.command.status.entities=엔티티,
+pocketmine.command.status.tiles=타일.
+pocketmine.command.status.Time=시간
+pocketmine.command.status.ms=ms
+
+pocketmine.command.gc.description=가비지 컬렉션 작업을 시작합니다
+pocketmine.command.gc.usage=/gc
+pocketmine.command.gc.title=컬렉션 보고서
+pocketmine.command.gc.chunks=청크:
+pocketmine.command.gc.entities=엔티티:
+pocketmine.command.gc.tiles=타일:
+pocketmine.command.gc.cycles=주기:
+pocketmine.command.gc.memory=릴리스 메모리:
+
+pocketmine.command.biome.description=영역의 바이옴을 변경합니다.(눈 또는 비 변경)
+pocketmine.command.biome.posset=Has set pos{%3} at:({%1},{%2})[{%0}]
+pocketmine.command.biome.get=현재 당신이 계신 바이옵의 ID는 {%0}입니다. 색상:{%1},{%2},{%3}
+pocketmine.command.biome.wrongLev=포인트를 각자 다른 레벨에서 설정할 수 없습니다.
+pocketmine.command.biome.wrongBio=잘못된 바이옴의 ID입니다. e.g. 1 (Plains), 2 (사막)，13 (Ice Mountains)，6 (Swampland)
+pocketmine.command.biome.wrongCol=잘못된 색입니다. e.g. 146,188,89 ."/biome get"을 사용하여 다른 색을 가져오세요.
+pocketmine.command.biome.noPos=영역을 선택하려면 먼저 "/biome pos1|pos2"를 사용해주세요.
+pocketmine.command.biome.set=바이옴을 다음으로 설정하였습니다：{%0}
+pocketmine.command.biome.color=색을 다음으로 설정하였습니다：{%0},{%1},{%2}
+
+pocketmine.command.timings.description=서버 성능 확인을 위해 타이밍을 기록합니다.
+pocketmine.command.timings.usage=/timings <reset|report|on|off|paste>
+pocketmine.command.timings.enable=타이밍 & 초기화 기능을 활성화하였습니다
+pocketmine.command.timings.disable=타이밍이 비활성화되었습니다.
+pocketmine.command.timings.timingsDisabled=/timings on를 사용하여 타이밍 기능을 활성화해주세요.
+pocketmine.command.timings.reset=타이밍을 초기화하였습니다
+pocketmine.command.timings.pasteError=보고목록에 붙이는 동안 에러가 발생 하였습니다.
+pocketmine.command.timings.timingsUpload=타이밍이 {%0}로 업로드가 되었습니다.
+pocketmine.command.timings.timingsRead=당신은 {%0} 에서 결과를 읽을수 있습니다.
+pocketmine.command.timings.timingsWrite=타이밍이 {%0}에 써졌습니다.
+pocketmine.command.version.description=현재 구동되고 있는 서버 버전과 플러그인 정보를 출력합니다.
+pocketmine.command.version.usage=/version [플러그인 이름]
+pocketmine.command.version.noSuchPlugin=입력하신 플러그인을 찾을 수 없습니다. /plugins를 입력해 플러그인 목록을 확인하세요.
+pocketmine.command.give.description=해당 플레이어에게 아이템을 지정한 양만큼 줍니다
+pocketmine.command.give.usage=/give <플레이어> <아이템[:손상 정도]> [양] [태그...]
+pocketmine.command.kill.description=자신 또는 다른 플레이어를 죽입니다
+pocketmine.command.kill.usage=/kill [죽일 플레이어]
+pocketmine.command.particle.description=월드에 파티클을 추가합니다.
+pocketmine.command.particle.usage=/particle <이름> <x> <y> <z> <xd> <yd> <zd> [양] [데이터]
+pocketmine.command.time.description=월드 시간을 변경합니다.
+pocketmine.command.time.usage=/time <set|add> <값> 또는 /time <start|stop|query>
+pocketmine.command.bancidbyname.description=지정된 플레이어의 CID가 서버에 접속할 수 없게 차단합니다
+pocketmine.command.bancid.description=지정된 CID가 서버에 들어오지 못하게 차단합니다
+pocketmine.command.banipbyname.description=지정된 플레이어의 IP 주소가 서버에 접속할 수 없게 차단합니다
+pocketmine.command.ban.player.description=지정된 플레이어가 서버에 들어오지 못하게 차단합니다
+pocketmine.command.ban.ip.description=지정된 IP 주소가 서버에 접속할 수 없게 차단합니다
+pocketmine.command.banlist.description=이 서버에서 차단한 모든 플레이어 목록을 보여줍니다.
+pocketmine.command.defaultgamemode.description=기본 게임모드를 설정합니다
+pocketmine.command.deop.description=지정된 플레이어의 OP 권한을 해제합니다
+pocketmine.command.difficulty.description=게임의 난이도를 설정합니다.
+pocketmine.command.enchant.description=아이템에 마법을 부여합니다
+pocketmine.command.effect.description=플레이어에게 효과를 부여하거나 제거합니다.
+pocketmine.command.gamemode.description=지정된 플레이어의 게임 모드를 변경합니다
+pocketmine.command.help.description=모든 명령어 목록을 보여줍니다.
+pocketmine.command.kick.description=해당 플레이어를 서버에서 퇴장시킵니다
+pocketmine.command.list.description=현재 접속 중인 플레이어의 목록을 보여줍니다
+pocketmine.command.me.description=채팅에서 지정된 동작을 합니다
+pocketmine.command.op.description=지정된 플레이어에게 OP 권한을 부여합니다
+pocketmine.command.unban.cid.description=지정된 CID가 서버를 이용할 수 있도록 차단 해제합니다
+pocketmine.command.unban.player.description=해당 플레이어의 차단을 해제합니다.
+pocketmine.command.unban.ip.description=지정된 IP 주소가 서버를 이용할 수 있도록 차단 해제합니다
+pocketmine.command.save.description=서버를 디스크에 저장합니다
+pocketmine.command.saveoff.description=서버 자동 저장을 비활성화합니다
+pocketmine.command.saveon.description=서버 자동 저장을 활성화합니다
+pocketmine.command.say.description=입력된 메시지를 서버 전체에 표시합니다
+pocketmine.command.seed.description=월드의 시드를 보여줍니다.
+pocketmine.command.setworldspawn.description=월드의 부활 지점을 지정합니다. 좌표를 입력하지 않으면 현재 플레이어의 좌표로 지정됩니다.
+pocketmine.command.spawnpoint.description=플레이어의 부활 지점을 정합니다
+pocketmine.command.stop.description=서버를 정지합니다
+pocketmine.command.tp.description=해당 플레이어 (또는 자신을) 지정한 플레이어나 좌표로 이동시킵니다
+pocketmine.command.tell.description=해당 플레이어에게 개인 메세지를 보냅니다
+pocketmine.command.xp.description=지정한 플레이어에게 경험치 또는 경험치 레벨을 줍니다
+pocketmine.command.summon.description=플레이어의 위치나 지정된 위치에 엔티티를 생성합니다
+pocketmine.command.fill.description=지정된 영역을 블럭으로 채웁니다
+pocketmine.command.setblock.description=블럭을 다른 블럭으로 변경합니다
+
+pocketmine.command.weather.description=레벨의 날씨를 설정합니다
+pocketmine.command.weather.usage=/weather <레벨 이름 또는 날씨|날씨 (rain|sunny|clear)>
+pocketmine.command.weather.changed=성공적으로 날씨를 레벨 {%0}에서 변경하였습니다!
+pocketmine.command.weather.noregistered=레벨 {%0}(은)는 WeatherManager에 등록되지 않았습니다.
+pocketmine.command.weather.invalid=잘못된 날씨입니다.(0,1,2,3)
+pocketmine.command.weather.wrong=잘못된 매개 변수 입니다.
+pocketmine.command.weather.invalid.level=올바르지 않은 레벨 이름입니다.
+
+pocketmine.command.whitelist.description=서버를 이용할 수 있는 플레이어 목록을 관리합니다
+pocketmine.crash.create=복구가 불가능한 오류가 발생하여 서버가 강제로 종료되었습니다. 크래시 덤프를 생성합니다.
+pocketmine.crash.error=크래시 덤프를 생성하지 못했습니다: {%0}
+pocketmine.crash.submit="{%0}"파일을 Crash Archive에 업로드하고 버그 리포팅 페이지에 링크를 보내 주세요. 가능한 한 많은 정보를 주시면 감사하겠습니다.
+pocketmine.crash.archive=크래시 덤프가 자동으로 Crash Archive에 전송되었습니다. {%0}에서 확인하거나 ID #{%1}을 사용하세요.
+pocketmine.debug.enable=LevelDB 지원이 활성화되었습니다
+pocketmine.player.invalidMove={%0}님이 잘못된 움직임을 보였습니다!
+pocketmine.player.logIn={%0}[/{%1}:{%2}] 이 엔티티 ID {%3} (으)로 ({%4}, {%5}, {%6}, {%7})에 접속했습니다
+pocketmine.player.logOut={%0}[/{%1}:{%2}] 님의 연결이 끊어졌습니다. 이유: {%3}
+pocketmine.player.transferred={%0}[/{%1}:{%2}] 님이 {%3}로 옮겨졌습니다
+pocketmine.player.invalidEntity={%0}이 유효하지 않은 엔티티를 공격하려 시도했습니다
+pocketmine.plugin.load=플러그인 {%0}을(를) 로딩 중입니다.
+pocketmine.plugin.enable=플러그인 {%0}을(를) 활성화 중입니다
+pocketmine.plugin.disable=플러그인 {%0}을(를) 비활성화 중입니다
+pocketmine.plugin.restrictedName=제한된 이름입니다!
+pocketmine.plugin.incompatibleAPI=호환되지 않는 API 버전입니다!
+pocketmine.plugin.unknownDependency=알 수 없는 의존 플러그인입니다!
+pocketmine.plugin.circularDependency=순환 의존성이 탐지되었습니다
+pocketmine.plugin.genericLoadError=플러그인 '{%0}'을(를) 로드하지 못했습니다
+pocketmine.plugin.spacesDiscouraged=플러그인 '{%0}'의 이름에 공백 문자가 섞여 있습니다. 이는 권장되지 않습니다.
+pocketmine.plugin.loadError=플러그인 '{%0}'을(를) 로드하지 못했습니다: {%1}
+pocketmine.plugin.duplicateError=플러그인 '{%0}'을(를) 로드하지 못했습니다: 이미 존재하는 플러그인입니다
+pocketmine.plugin.fileError=폴더 '{%1}'에서 플러그인 '{%0}'을(를) 로드하지 못했습니다: {%2}
+pocketmine.plugin.commandError=명령어 {%0}을(를) 플러그인 {%1}에서 로드하지 못했습니다
+pocketmine.plugin.aliasError=플러그인 {%1}의 명령어 별칭 {%0}을(를) 로드하지 못했습니다
+pocketmine.plugin.deprecatedEvent=플러그인 '{%0}'이(가) 이벤트 '{%1}'을(를) 위한 리스너를 메서드 '{%2}'에 대해 추가했지만, 이 이벤트의 사용은 권장되지 않습니다.
+pocketmine.plugin.eventError="이벤트 '{%0}'을(를) 플러그인 '{%1}'에 전달하지 못했습니다: {%2} ({%3})"

--- a/src/pocketmine/resources/genisys_kor.yml
+++ b/src/pocketmine/resources/genisys_kor.yml
@@ -1,0 +1,167 @@
+#Genisys 고급 구성 파일
+
+#Version 파일의 버전
+config:
+ version: 19
+
+level:
+ #날씨 시스템을 켜는 경우 설정하세요
+ weather: true
+ #날씨 랜덤 기간
+ weather-random-duration-min: 6000
+ weather-random-duration-max: 12000
+ #랜덤 번개 치는 주기，기본은 10초, 0 = 비활성화
+ lightning-time: 200
+ #번개가 불과 함께 치게 하려는 경우 설정하세요
+ lightning-fire: false
+ #불이 번지는 것을 활성화 하려는 경우 설정하세요
+ fire-spread: false
+ 
+player:
+ #배고픔 시스템 스위치
+ hunger: true
+ #허기로 인하여 생명이 닳을 때 최소 생명
+ hunger-health: 10
+ #허기 시간 카운터, 기본: 80=4초
+ hunger-timer: 3000
+ #경험치 시스템을 켜는 경우 고르세요
+ experience: true
+ #플레이어가 사망하였을때 인벤토리를 유지하려는 경우 고르세요
+ keep-inventory: false
+ #게임 모드를 크리에이티브로 변경하는 경우 자동으로 인벤토리를 비웁니다
+ auto-clear-inventory : true
+ #플레이어가 사망하였을때 경험치를 유지하려는 경우 고르세요
+ keep-experience: false
+ #플레이어들이 참여했을때 크래시가 발생하는 경우, 이 값을 10 이하로 설정하세요. 비활성화=-1
+ chunk-radius: -1
+
+nether:
+ #지옥이 활성화 된 경우 고르세요. 지옥 레벨이 자동으로 생성됩니다.
+ allow-nether: true
+ #지옥 레벨의 이름
+ level-name: "nether"
+ 
+server:
+ #경험치 데이터를 미리 생성합니다，0=비활성화
+ experience-cache: 65535
+ #철 골램을 생성하는 것이 허용된 경우 고르세요
+ allow-iron-golem: false
+ #눈 골렘을 생성하는 것이 허용된 경우 고르세요
+ allow-snow-golem: false
+ #server.log를 비활성화 하는 경우 고르세요
+ disable-log: false
+ #자동 비행 방지를 활성화 하는 경우 고르세요
+ anti-fly: true
+ #비동기 청크 요청을 활성화 하는 경우 고르세요
+ async-chunk-request: true
+ #플레이어가 참여할 때 뜨는 메시지를 고릅니다
+ #0 = 메시지, 1 = 팁, 2 = 팝업
+ player-msg-type: 0
+ login-msg: "§3@player joined the game"
+ logout-msg: "§3@player left the game"
+ #레시피를 json에서 가져오는 경우 고르세요
+ recipes-from-json: false
+ #크리에이티브 아이템을 json에서 가져오는 경우 고르세요
+ creative-items-from-json: false
+ #움직임 확인을 활성화 하는 경우 고르세요 (더 이상 뒤로 당겨지지 않음)
+ check-movement: true
+ #제한된 크리에이티브를 활성화 하는 경우 설정하세요 (아이템 드롭 불가, 상자 열기 불가 등)
+ limited-creative: true
+ #블럭 파괴 파티클을 추가하는 경우 설정하세요
+ destroy-block-particle: true
+ #투척용 포션을 활성화 하는 경우 고르세요
+ allow-splash-potion: true
+ #고급 명령어 선택기를 활성화 하는 경우 설정하세요
+ advanced-command-selector: false
+
+enchantment:
+ #모루가 허용된 경우 고르세요
+ enable-anvil: true
+ #마법 부여대가 허용된 경우 고르세요
+ enable-enchanting-table: true
+ #책장의 수를 세려는 경우 활성화 하세요. 서버 랙을 유발할 수도 있습니다.
+ #만약 이 옵션이 false인 경우, 서버는 랜덤 카운트를 사용할 것 입니다 (0~15)
+ count-bookshelf: false
+
+redstone:
+ #####################################
+ ######레드스톤 시스템이 허용된 경우 고르세요######
+ #####################################
+ #만약 true가 아닌 경우 레드스톤이 작동하지 않습니다#
+ #####################################
+ enable: false
+ #주파수 펄스를 허용하는 경우 고르세요
+ frequency-pulse: false
+ #펄스 주파수 설정, 기본: 1초
+ pulse-frequency: 1
+
+synapse:
+ #Synapse API나 Synapse 서버 연결을 사용하고 싶으신 경우, 이 설정을 활성화 하세요.
+ enabled: false
+ server-ip: 127.0.0.1
+ server-port: 10305
+ #이 클라이언트가 로비 또는 메인 서버인 경우
+ is-main-server: true
+ server-password: 32bitlongkey
+ #이 클라이언트의 설명은 이 클라이언트의 식별자입니다
+ description: "A Synapse client"
+ #RakLib 비활성화는 플레이어가 Synapse를 사용해서만 참여할 수 있음을 의미합니다
+ disable-rak: false
+
+dserver:
+ #모든 멀티 (다중) 서버의 수 통합
+ enable: false
+ #자동으로 쿼리 업데이트
+ query-auto-update: false
+ #쿼리 업데이트 주기
+ query-tick-update: true
+ #Motd 최대 플레이어 숫자
+ motd-max-players: 0
+ #쿼리 최대 플레이어 숫자，0=기본
+ query-max-players: 0
+ #motd에서 모든 플레이어의 숫자 표시
+ motd-all-players: false
+ #쿼리에서 모든 플레이어의 숫자 표시
+ query-all-players: false
+ #motd에서 온라인 플레이어의 숫자 표시
+ motd-players: false
+ #쿼리에서 온라인 플레이어의 숫자 표시
+ query-players: false
+ #업데이트 주기, 20=1초
+ time: 40
+ #실패한 경우 다시 시도할 빈도
+ retry-times: 3
+ #서버 목록，';'를 사용하여 분리하세요，예시: 1.example.com:19132;2.example.com:19133
+ server-list: ""
+ 
+ai:
+ #AI 스위치
+ enable: false
+ #좀비의 AI，0=비활성화，1=AI 1.0 버전，2=새로운 AI(불완전)
+ zombie: 1
+ #좀비 피그맨의 AI
+ pigzombie: true
+ #소와 버섯 소의 AI
+ cow: true
+ #닭의 AI
+ chicken: true
+ #양의 AI
+ sheep: true
+ #돼지의 AI
+ pig: true
+ #스켈레톤의 AI
+ skeleton: true
+ #크리퍼의 AI
+ creeper: true
+ #철 골램의 AI
+ iron-golem: true
+ #눈 골렘의 AI
+ snow-golem: true
+ #크리퍼가 폭발했을 때 블록 파괴
+ creeper-explode-destroy-block: false
+ #몹 자동 생성을 활성화 하는 경우 고르세요
+ mobgenerate: false
+ 
+inventory:
+ #모루와 관련된 문제가 있는 경우 true로 설정하세요. 인벤토리 처리를 vanila fashion (기본 방식)으로 치트 방지나 확인 없이 진행합니다.
+ allow-cheats: false

--- a/src/pocketmine/wizard/InstallerLang.php
+++ b/src/pocketmine/wizard/InstallerLang.php
@@ -29,7 +29,7 @@ class InstallerLang{
 		"zho" => "繁體中文",
 		"jpn" => "日本語",
 		"rus" => "Русский",
-		"ita" => "Italiano"
+		"ita" => "Italiano",
 		"kor" => "한국어"
 	];
 	private $texts = [];

--- a/src/pocketmine/wizard/InstallerLang.php
+++ b/src/pocketmine/wizard/InstallerLang.php
@@ -30,6 +30,7 @@ class InstallerLang{
 		"jpn" => "日本語",
 		"rus" => "Русский",
 		"ita" => "Italiano"
+		"kor" => "한국어"
 	];
 	private $texts = [];
 	private $lang;


### PR DESCRIPTION
### Description
Added Korean translation. On main translation (not installer) not all stuffs are translated, but most stuffs are translated. **Only few stuffs (about 5~8) are still remaing as English.** _P.S: Just found someone already did pull request of Korean translation, but Korean translation was already done by me (But didn't uploaded it as public using pull request). Also that user's main translation is just default frame of PocketMine-MP Korean translation, but I also translated Genisys message._

### Reason to modify
Because It's annoy to add my Korean translation by downloading src folder instead of phar, it's kinda annoy to do that! So I would like to release it as public and make others use it.

### Tests & Reviews
I have tested the code and it works.  You can try to use this by modifying language setting