### PR TITLE
Removed unnecessary mkdir call

### DIFF
--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -204,7 +204,6 @@ abstract class PluginBase implements Plugin{
 		$out = $this->dataFolder . $filename;
 		if(!file_exists(dirname($out))){
 			mkdir(dirname($out), 0755, true);
-			mkdir($this->dataFolder, 0755, true);
 		}
 
 		if(file_exists($out) and $replace !== true){


### PR DESCRIPTION
### Description
Removed unnecessary mkdir call.



### Reason to modify
This call to mkdir() is totally unnecessary. Legally, `$out` is somewhere equal to or inside the data folder, so the directory must have already been made on line 206. Even if illegally, this is totally unnecessary.

@PeratX [wtf](https://github.com/iTXTech/Genisys/blame/master/src/pocketmine/plugin/PluginBase.php#L207)? How come nobody found this out for over 6 months?

- Think twice before modifying: is it the best way? will it break things? 
  - What could it probably break?
- Have you made sure that there is actually a problem before trying to fix it?
  - I have an extra message on console when server starts. Do you call that a problem?
- Explain the logic behind your changes - WHY and HOW what you have done works
  - What about, explain the logic behind @PeratX's changes in d327a62?

### Tests & Reviews
<!-- Uncomment based on the situation -->

~~I have tested the code and it works.~~ I tested in my cerebrum. I didn't test on a server. Is that enough? Since a problem happens anyway, I don't think I can make it much worse.

<!-- Please review things below: -->

The following text is just for testing. Please ignore them.

# Plugins to test with Travis-CI
- https://gist.githubusercontent.com/SOF3/0ceda507ff03a376a6a7f4182b87db8e/raw/a403a81da6905a41da28b1928ffc305c5ffc75ed/test2.php
- [test1.php](https://gist.githubusercontent.com/SOF3/63682b7b04842b25596b18894f815ddc/raw/49783b48af65bf40600377c182932b7b39d6664c/test1.php)
- [test3.phar]  (https://forums.pocketmine.net/plugins/specter.894/download?version=2634)


