### PR TITLE
Download PR-specified plugins in Travis-CI build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,16 @@
 <!-- I have tested the code and it works. -->
 
 <!-- Please review things below: -->
+
+<!--
+If you want the Travis-CI build for this pull request to be run with extra plugins,
+please uncomment the following lines, and follow the formats below EXACTLY. Do NOT include any inline or post-line comments.
+-->
+<!-- # Plugins to test with Travis-CI
+- [this-is-the-file-name-in-plugins-folder.php](http://path.to/script-plugin-download)
+- [this-is-a.phar](http://path.to-phar-download)
+- https://file-extensions.will.be/auto-detected/if/only/URL/is/given
+-->
+
+<!-- END -->
+

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -3,7 +3,7 @@ mkdir plugins
 curl -fsSL https://github.com/iTXTech/DevTools/releases/download/v1.1-iTX/DevTools_v1.1-iTX.phar -o plugins/DevTools.phar
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     curl -sSL https://api.github.com/repos/iTxTech/Genisys/pulls/"$TRAVIS_PULL_REQUEST" | \
-        php tests/ciDlPlugins.php "$(realpath plugins)"
+        php tests/ciDlPlugins.php plugins/
 fi
 echo Running lint...
 shopt -s globstar

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 mkdir plugins
 curl -fsSL https://github.com/iTXTech/Genisys-DevTools/releases/download/1.0.0/Genisys-DevTools_v1.0.0.phar -o plugins/Genisys-DevTools.phar
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    curl -sSL https://api.github.com/repos/iTxTech/Genisys/pulls/"$TRAVIS_PULL_REQUEST" | \
+        php tests/ciDlPlugins.php "$(realpath plugins)"
+fi
 echo Running lint...
 shopt -s globstar
 for file in **/*.php; do

--- a/tests/ciDlPlugins.php
+++ b/tests/ciDlPlugins.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * GETs an URL using cURL
+ *
+ * Source: src/pocketmine/utils/Utils.php
+ *
+ * @param     $page
+ * @param int $timeout default 10
+ * @param array $extraHeaders
+ *
+ * @return bool|mixed
+ */
+function getURL($page, $timeout = 10, array $extraHeaders = []){
+	$ch = curl_init($page);
+	curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge(
+			["User-Agent: Genisys-CI/1.0"], // required by GitHub API
+			$extraHeaders));
+	curl_setopt($ch, CURLOPT_AUTOREFERER, true);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+	curl_setopt($ch, CURLOPT_FORBID_REUSE, 1);
+	curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
+	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, (int) $timeout);
+	curl_setopt($ch, CURLOPT_TIMEOUT, (int) $timeout);
+	$ret = curl_exec($ch);
+	curl_close($ch);
+
+	return $ret;
+}
+
+function is_url($url){
+	return filter_var($url, FILTER_VALIDATE_URL);
+}
+
+if(!defined("STDERR")){
+	define("STDERR", fopen("php://stderr", "wt"));
+}
+
+define("PLUGINS_DIR", realpath($argv[1] ?? (dirname(__DIR__) . "/plugins/")) . "/");
+
+$json = file_get_contents("php://stdin");
+$data = json_decode($json);
+if(!is_object($data)){
+	fwrite(STDERR, "Failed to access GitHub API" . PHP_EOL);
+	return;
+}
+
+if(isset($data->message, $data->documentation_url)){
+	fwrite(STDERR, "GitHub API error: $data->message" . PHP_EOL);
+	return;
+}
+
+if(!isset($data->body)){
+	fwrite(STDERR, "GitHub API did not return expected value for pull request body" . PHP_EOL);
+	return;
+}
+
+$body = $data->body;
+
+foreach(explode("\n", $body) as $i => $line){
+	$line = trim($line);
+	if($line === "# Plugins to test with Travis-CI"){
+		$started = true;
+		continue;
+	}
+	if(!isset($started)){
+		continue;
+	}
+
+	if($line === "<!-- END -->"){
+		break;
+	}
+	if(strlen($line) === 0){
+		break;
+	}
+	if(substr($line, 0, 5) === "<!-- "){
+		continue;
+	}
+
+	unset($name);
+	if(preg_match('%^\-[ \t]*(http(s)?://.*$)%i', $line, $match)){
+		$url = $match[1];
+	}elseif(preg_match('%^\-[ \t]*\[([^\]]+)\][ \t]*\(([^\)]+)\)$%i', $line, $match)){
+		list(, $name, $url) = $match;
+	}else{
+		break;
+	}
+	if(!is_url($url)){
+		break;
+	}
+
+	$plugin = getURL($url);
+	if(!is_string($plugin)){
+		fwrite(STDERR, "Failed to download plugin " . ($name ?? $url) . PHP_EOL);
+		break;
+	}
+
+	if(isset($name)){
+		file_put_contents(PLUGINS_DIR . $name, $plugin);
+		continue;
+	}
+
+	if(strpos($plugin, "__HALT_COMPILER();") !== false){ // probably a phar
+		file_put_contents($file = PLUGINS_DIR . "Genisys-CI-Untitled-$i.phar", $plugin);
+		try{
+			$phar = new Phar($file);
+		}catch(UnexpectedValueException $e){
+			rename($file, PLUGINS_DIR . "Genisys-CI-Untitled-$i.php");
+		}
+	}else{
+		file_put_contents(PLUGINS_DIR . "Genisys-CI-Untitled-$i.php", $plugin);
+	}
+}
+


### PR DESCRIPTION
### Description
This pull request changes the Travis build script. The build will download a list of plugins specified in the pull request body, and run the test server with them. The plugin list section starts with this line:

```markdown
# Plugins to test with Travis-CI                                                                                                                 <!-- IGNORE THIS COMMENT - this comment is for INTERNAL use -->
```

Followed by a plugin list, where plugins can be specified in these formats:

```markdown
- http://url.here
- [file-name.php](https://url.here)
```

If the former format is used, a file `Genisys-CI-Untitled-%d.%s` will be created, where `%d` is the line number - 1 of the line that specified the plugin in the pull request body, and `%s` is `php` or `phar`, detected in this algorithm:

```vbs
if __HALT_COMPILER exists in the file
then
    attempt to create Phar object from this file
    if UnexpectedValueException is thrown
    then
        implies that it is not a valid phar
        set file extension to .php
    else
        set file extension to .phar
    end if
else
    set file extension to .php
end if
```

The plugin list section is terminated by:
* a line exactly `<!-- END -->`  when trimmed
* a line without visible characters (`strlen(trim($line)) === 0`)
* a line that does not match any of the two formats above
* end of file

And skips but is not terminated by other lines starting with `<!-- `.

Examples are present as followings:

# Plugins to test with Travis-CI
- https://gist.githubusercontent.com/SOF3/04cf1f3ced0d062a3bf7578ab086e692/raw/738f5aaaa6b58c6ba6a01b025a77f8affbcdb3a1/plugin.php
<!-- This line should be skipped -->
<!-- END -->

### Reason to modify
Travis-CI is usually useless for pull requests related to plugin API. In order to maximize the
- https://gist.githubusercontent.com/SOF3/7ab7222ec3c76bd3c5dad73fc26b0cb4/raw/21a6f327b5cf550e1dbe77bb08d81ce1f3fb66f4/plugin.php
 usage of Travis-CI, this pull request allows future pull requests to validate that they work through attaching links to plugins that can test against their features. These can be instant script plugins on GitHub Gist/other pastebin sites, or preexisting plugins that are known to use a certain API feature.

Plugins can also be created to stress test the server from different approaches.

### Tests & Reviews
I have tested `ciDlPlugins.php` and it works.

I have **not** tested how the modified `.travis.yml` works on Travis-CI yet, especially when it comes to GitHub API rate limit. However, through careful manual inspection, it seems to be correct.

### Possible enhancements/fixes
- [ ] Fix issue about GitHub API rate limit on Travis-CI
   - [ ] Setup a [proxy page](https://gist.github.com/SOF3/06c085d8bbf69b44b16acceca8711509) on a server officially specialized for Genisys, which will help access GitHub API with a private GitHub access token
- [ ] Allow more syntax flexibility when listing the plugins
- [ ] Test server twice, once with plugins, once without plugins. Probably even checkout BASE and run test with plugins there as well.
- [x] ~~Extend this feature to normal commits (but probably would never get useful)~~ _CI on the master branch is more useful to test the stability of the software rather than the stability of an individual commit. **wontfix**_
- [x] ~~Load from attached files in pull request main comment~~ _GitHub doesn't allow uploading `.php` files_
