### PR TITLE
Feature update: Add ability to enable/disable commands in pocketmine.yml

### DIFF
--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -155,6 +155,17 @@ anonymous-statistics:
  enabled: true
  host: stats.pocketmine.net
 
+commands:
+ #Here you can customize server commands
+ #Specify command names to override the default set here.
+ #If no custom value is defined for a command, the default will be used.
+ #NOTE: Some commands cannot be disabled here, such as the important ones like /stop, /reload, etc.
+ default: true
+ #Set override values per command here
+ #For example, uncommenting the below will disable /plugins and /version
+ #version: false
+ #plugins: false
+
 aliases:
  #Examples:
  #showtheversion: version


### PR DESCRIPTION
### Description
This PR adds the ability to enable or disable commands in pocketmine.yml, allowing server owners to declutter the /help command of useless commands.

### How this works
It's quite straightforward. Under the new `commands` section in pocketmine.yml there is a default behaviour option. This will be used when no specific configuration is set for a command. Setting the default as FALSE will provide a whitelist behaviour (only the commands you select are enabled). Setting the default as TRUE will provide a blacklist behaviour (remove commands you don't want).

To set specific behaviour for a command, simply add a key under the `commands` section with the name of the command you want to override the default for. For example, using the whitelist behaviour and wanting to disable the /version and /plugins  commands, I would do this:
```
commands:
 #Here you can customize server commands
 #Specify command names to override the default set here.
 #If no custom value is defined for a command, the default will be used.
 #NOTE: Some commands cannot be disabled here, such as the important ones like /stop, /reload, etc.
 default: true
 #Set override values per command here
 #For example, uncommenting the below will disable /plugins and /version
 version: false
 plugins: false
```

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Add ability for server owners to remove commands that are never used. For example, I never use /bancid, but no doubt it comes in useful for other people. 
This works by preventing disabled commands from being loaded.

#### Things worth noting:
- This does NOT block commands; it prevents disabled commands from being loaded at all. This is therefore less flexible than using a permissions plugin as it cannot be changed at runtime. However, if all you want to do is remove some commands that you never use, then this will be a bonus.
- Some commands cannot be disabled for obvious reasons, such as /help, /stop, /reload

### Tests & Reviews
I have tested this under both white- and blacklist configuration and found no issues. Please comment below if you encounter issues.

### Please review things below:
- This configuration will also affect plugin commands. Whether or not this behaviour should be retained is something I'm unsure on. Please comment.