### PR TITLE
Fixes #1857, closes #1859

### DIFF
--- a/src/pocketmine/entity/Painting.php
+++ b/src/pocketmine/entity/Painting.php
@@ -27,9 +27,9 @@ class Painting extends Hanging{
 	}
 
 	public function attack($damage, EntityDamageEvent $source){
-		parent::attack($damage, $source);
-
-		$this->close();
+		if(parent::attack($damage, $source)){
+			$this->close();
+		}
 	}
 
 	public function spawnTo(Player $player){


### PR DESCRIPTION
### Description
Fixes #1857. Replaces #1859.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Refer to @dktapps's rejection comment on #1859.

### Tests & Reviews
<!-- Uncomment based on the situation -->
I have **not** tested the code and it **most likely** works. Reason: I don't have any device installed with MCPE. I did not buy MCPE. I hereby declare that both statements above are true.

Mental simulation:
1. Not-yet-called event is passed to `Painting::attack`
2. Delegation to parent `Entity::attack` from `Painting::attack` (`Painting.php:30`)
3. Event is called in `Entity::attack`. (`Entity.php:684`)
4. Event is cancelled by plugins.
5. Event is found to be cancelled by plugins, so `Entity::attack` returns false to `Painting::attack`. (`Entity.php:685`)
6. Only if the delegation to parent returns true (event is not cancelled and no exceptions thrown), `Painting::close` is triggered (`Painting.php:31`). If delegation to parent returns false (event is cancelled), nothing happens on the Painting class.