### PR TITLE
Fix https://github.com/iTXTech/Genisys/issues/1857

### DIFF
--- a/src/pocketmine/entity/Painting.php
+++ b/src/pocketmine/entity/Painting.php
@@ -28,8 +28,9 @@ class Painting extends Hanging{
 
 	public function attack($damage, EntityDamageEvent $source){
 		parent::attack($damage, $source);
-
-		$this->close();
+		if($source->isCancelled()){
+			return;
+		}
 	}
 
 	public function spawnTo(Player $player){

--- a/src/pocketmine/entity/Painting.php
+++ b/src/pocketmine/entity/Painting.php
@@ -11,6 +11,8 @@ use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\network\protocol\AddPaintingPacket;
 use pocketmine\item\Item as ItemItem;
 use pocketmine\Player;
+use pocketmine\level\particle\DestroyBlockParticle;
+use pocketmine\block\Block;
 
 class Painting extends Hanging{
 	const NETWORK_ID = 83;
@@ -28,9 +30,9 @@ class Painting extends Hanging{
 
 	public function attack($damage, EntityDamageEvent $source){
 		parent::attack($damage, $source);
-		if($source->isCancelled()){
-			return;
-		}
+		if($source->isCancelled()) return false;
+		$this->level->addParticle(new DestroyBlockParticle($this->add(0.5), Block::get(Block::LADDER)));
+		$this->kill();
 	}
 
 	public function spawnTo(Player $player){


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Same like before, 100% tested. Only if the even't is not cancelled, particles play and the painting item drops.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Old PR was missing a "false"
### Tests & Reviews
<!-- Uncomment based on the situation -->
<!-- I have tested the code and it works. -->
Tested with simple entity damage cancelling plugin.
<!-- Please review things below: -->
