### PR TITLE
Generator: Fix Void generator

### DIFF
--- a/src/pocketmine/level/generator/Void.php
+++ b/src/pocketmine/level/generator/Void.php
@@ -36,6 +36,8 @@ class Void extends Generator{
 	/** @var Random */
 	private $random;
 	private $options;
+	/** @var FullChunk */
+	private $emptyChunk = null;
 
 	public function getSettings(){
 		return [];
@@ -55,25 +57,33 @@ class Void extends Generator{
 	}
 
 	public function generateChunk($chunkX, $chunkZ){
-		$this->chunk = clone $this->level->getChunk($chunkX, $chunkZ);
-		$this->chunk->setGenerated();
-		$c = Biome::getBiome(1)->getColor();
-		$R = $c >> 16;
-		$G = ($c >> 8) & 0xff;
-		$B = $c & 0xff;
+		if($this->emptyChunk !== null){
+			//Use the cached empty chunk instead of generating a new one
+			$this->chunk = clone $this->emptyChunk;
+		}else{
+			$this->chunk = clone $this->level->getChunk($chunkX, $chunkZ);
+			$this->chunk->setGenerated();
+			$c = Biome::getBiome(1)->getColor();
+			$R = $c >> 16;
+			$G = ($c >> 8) & 0xff;
+			$B = $c & 0xff;
 
-		for($Z = 0; $Z < 16; ++$Z){
-			for($X = 0; $X < 16; ++$X){
-				$this->chunk->setBiomeId($X, $Z, 1);
-				$this->chunk->setBiomeColor($X, $Z, $R, $G, $B);
-				for($y = 0; $y < 128; ++$y){
-					$this->chunk->setBlockId($X, $y, $Z, Block::AIR);
+			for($Z = 0; $Z < 16; ++$Z){
+				for($X = 0; $X < 16; ++$X){
+					$this->chunk->setBiomeId($X, $Z, 1);
+					$this->chunk->setBiomeColor($X, $Z, $R, $G, $B);
+					for($y = 0; $y < 128; ++$y){
+						$this->chunk->setBlockId($X, $y, $Z, Block::AIR);
+					}
 				}
 			}
+			$spawn = $this->getSpawn();
+			if($spawn->getX() >> 4 === $chunkX and $spawn->getZ() >> 4 === $chunkZ){
+				$this->chunk->setBlockId(0, 64, 0, Block::GRASS);
+			}else{
+				$this->emptyChunk = $this->chunk;
+			}
 		}
-
-		$this->chunk->setBlockId(8, 64, 8, Block::GRASS);
-
 		$chunk = clone $this->chunk;
 		$chunk->setX($chunkX);
 		$chunk->setZ($chunkZ);


### PR DESCRIPTION
### Description
Fix the SkyGrid fail in the Void generator.

### Reason to modify
- Generate a "void" world with the current generator. Result = a grid of grass blocks at about y = 64 and players plummet to their deaths on spawn.
- With my generator, only ONE grass block is generated - in the spawn chunk. This provides a place to stand and players will spawn on this block. It also provides something to build against.

This works by checking if the spawn coordinates are within the chunk we are currently generating. If yes, we add a grass block. If no, we cache a copy of the blank chunk we created and store it so that we don't need to continually regenerate empty chunks. This should improve generation efficiency.

### Tests & Reviews
I have tested the code and it works.

Before:
![screenshot_20160905-235601](https://cloud.githubusercontent.com/assets/14214667/18258004/4d5eb51e-73c5-11e6-9b6d-a71004e3315d.png)

After:
![screenshot_20160905-235339](https://cloud.githubusercontent.com/assets/14214667/18258005/52b745c6-73c5-11e6-9f64-47d250ae7624.png)