### PR TITLE
Safer method for disabling log at runtime

### DIFF
--- a/src/pocketmine/utils/MainLogger.php
+++ b/src/pocketmine/utils/MainLogger.php
@@ -37,7 +37,7 @@ class MainLogger extends \AttachableThreadedLogger{
 	private $consoleCallback;
 
 	/** Extra Settings */
-	protected $write = true;
+	protected $write = false;
 
 	public $shouldSendMsg = "";
 	public $shouldRecordMsg = false;
@@ -280,24 +280,23 @@ class MainLogger extends \AttachableThreadedLogger{
 
 	public function run(){
 		$this->shutdown = false;
-		if($this->write){
-			//$this->logResource = file_put_contents($this->logFile, "a+b", FILE_APPEND);
-
-			while($this->shutdown === false){
-				if(!$this->write) break;
-				$this->synchronized(function(){
-					while($this->logStream->count() > 0){
-						$chunk = $this->logStream->shift();
-						$this->logResource = file_put_contents($this->logFile, $chunk, FILE_APPEND);
-					}
-
-					$this->wait(200000);
-				});
-			}
-
-			if($this->logStream->count() > 0){
+		while($this->shutdown === false){
+			$this->synchronized(function(){
 				while($this->logStream->count() > 0){
 					$chunk = $this->logStream->shift();
+					if($this->write){
+						$this->logResource = file_put_contents($this->logFile, $chunk, FILE_APPEND);
+					}
+				}
+
+				$this->wait(200000);
+			});
+		}
+
+		if($this->logStream->count() > 0){
+			while($this->logStream->count() > 0){
+				$chunk = $this->logStream->shift();
+				if($this->write){
 					$this->logResource = file_put_contents($this->logFile, $chunk, FILE_APPEND);
 				}
 			}


### PR DESCRIPTION
### Description
This **may** fix the issue outlined in #1709. 

### Reason to modify
Previously, the logger writing to file is enabled by default, and will log a couple of lines before it is disabled. Now, I'm not 100% sure what's going on, but the `synchronized` combined with the fact that the logging to file will be unceremoniously broken off when the log is disabled by config led me to this.

This is a cleaner solution which only affects the actual file content writing. File write is also off by default, so it will only start when the config is loaded.

### Tests & Reviews
<!-- Uncomment based on the situation -->
I have tested the code and it doesn't crash or cause any noticeable issues. However,  I cannot verify whether it fixes the aforementioned issue or not. Please test and review.

<!-- Please review things below: -->

