### PR TITLE
Arrrows now don't affect spectators

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1989,6 +1989,9 @@ class Level implements ChunkManager, Metadatable{
 			for($x = $minX; $x <= $maxX; ++$x){
 				for($z = $minZ; $z <= $maxZ; ++$z){
 					foreach($this->getChunkEntities($x, $z) as $ent){
+						if($ent instanceof Player and $ent->isSpectator()){
+							continue;
+						}
 						if($entity == null){
 							if($ent->boundingBox->intersectsWith($bb)){
 								$nearby[] = $ent;
@@ -2025,6 +2028,9 @@ class Level implements ChunkManager, Metadatable{
 		for($x = $minX; $x <= $maxX; ++$x){
 			for($z = $minZ; $z <= $maxZ; ++$z){
 				foreach($this->getChunkEntities($x, $z) as $ent){
+					if($ent instanceof Player and $ent->isSpectator()){
+						continue;
+					}
 					if($ent !== $entity and $ent->boundingBox->intersectsWith($bb)){
 						$nearby[] = $ent;
 					}


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
This PR fixes all projectiles.


### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Try to login to one server from two devices, give creative for first, spectator for second. Now try to shoot from first to invisible spectators, arrows will stop moving on second player.

### Tests & Reviews
<!-- Uncomment based on the situation -->

I have tested the code and it works.

<!-- Please review things below: -->

