### PR TITLE
Fix a bug with updateAround only updating one block. Close #1618

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1115,6 +1115,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Vector3 $pos
 	 */
 	public function updateAround(Vector3 $pos){
+		$pos = $pos->floor();
 		$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($pos->x, $pos->y - 1, $pos->z))));
 		if(!$ev->isCancelled()){
 			$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);


### PR DESCRIPTION
### Description
Fix #1618 - updateAround only updates one block.

### Reason to modify
- See #1618 for method to reproduce this bug.

As best I can understand, updateAround was being supplied with a floating-point Vector3, which when offset by +/-1, caused rounding errors resulting in the same block being updated several times. This fixes the issue by flooring the Vector3 before updating anything.

### Tests & Reviews
I have tested the code and it works flawlessly.
Tests:
 - Place a block and attach torches to all sides, then break the block. The torches will now all be updated.