### PR TITLE
Fix #1926

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1002,9 +1002,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->setAllowFlight($this->gamemode == 3 || $this->gamemode == 1);
 		
 		$this->setHealth($this->getHealth());
-		if($this->server->foodEnabled) $this->setFood($this->getFood());
-		else $this->setFood(20);
-
+		$this->setFood($this->getFood());
+		
 		$this->server->getPluginManager()->callEvent($ev = new PlayerJoinEvent($this, new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.joined", [
 			$this->getDisplayName()
 		])));

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -998,6 +998,12 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 
 		$this->teleport($pos);
+		
+		$this->setAllowFlight($this->gamemode == 3 || $this->gamemode == 1);
+		
+		$this->setHealth($this->getHealth());
+		if($this->server->foodEnabled) $this->setFood($this->getFood());
+		else $this->setFood(20);
 
 		$this->server->getPluginManager()->callEvent($ev = new PlayerJoinEvent($this, new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.joined", [
 			$this->getDisplayName()
@@ -1009,8 +1015,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			elseif($this->server->playerMsgType === Server::PLAYER_MSG_TYPE_POPUP) $this->server->broadcastPopup(str_replace("@player", $this->getName(), $this->server->playerLoginMsg));
 		}
 
-		$this->setAllowFlight($this->gamemode == 3 || $this->gamemode == 1);
-
 		$this->server->onPlayerLogin($this);
 		$this->spawnToAll();
 
@@ -1019,9 +1023,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			//$this->checkExpLevel();
 			$this->updateExperience();
 		}
-		$this->setHealth($this->getHealth());
-		if($this->server->foodEnabled) $this->setFood($this->getFood());
-		else $this->setFood(20);
 
 		if($this->server->dserverConfig["enable"] and $this->server->dserverConfig["queryAutoUpdate"]) $this->server->updateQuery();
 


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
This fixes bugs, when plugins calls `Player::setAllowFlight`, `Player::setHealth` or `Player::setFood` in `PlayerJoinEvent`.


### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
I'm want to use this methods in `PlayerJoinEvent`.

### Tests & Reviews
<!-- Uncomment based on the situation -->

I have tested the code and it works.

<!-- Please review things below: -->

