### PR TITLE
New API for exp calculation. Fix #1930 and remove lots of stupidity.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Genisys
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "Genisys API 1.9.1"
+PROJECT_NUMBER         = "Genisys API 1.9.2"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -64,7 +64,6 @@ use pocketmine\event\player\PlayerChatEvent;
 use pocketmine\event\player\PlayerCommandPreprocessEvent;
 use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerDropItemEvent;
-use pocketmine\event\player\PlayerExperienceChangeEvent;
 use pocketmine\event\player\PlayerGameModeChangeEvent;
 use pocketmine\event\player\PlayerHungerChangeEvent;
 use pocketmine\event\player\PlayerInteractEvent;
@@ -172,7 +171,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	const ADVENTURE = 2;
 	const SPECTATOR = 3;
 	const VIEW = Player::SPECTATOR;
-	
+
 	const CRAFTING_SMALL = 0;
 	const CRAFTING_BIG = 1;
 	const CRAFTING_ANVIL = 2;
@@ -338,109 +337,106 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		]);
 	}
 
-	protected $expLevel = 0;
-	protected $exp = 0;
-	protected $expCooldown = 0;
-
+	/**
+	 * @deprecated Use Human::setTotalXp($xp), this method will be removed in the future.
+	 */
 	public function setExperienceAndLevel(int $exp, int $level){
-		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $exp, $level));
-		if(!$ev->isCancelled()){
-			$this->expLevel = $level;
-			$this->exp = $exp;
-			$this->expCooldown = microtime(true);
-			$this->calcExpLevel();
-			$this->updateExperience();
-			return true;
-		}
-		return false;
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->setTotalXp(self::getTotalXpRequirement($level) + $exp);
 	}
 
+	/**
+	 * @deprecated Use Human::setTotalXp($xp), this method will be removed in the future.
+	 */
 	public function setExp(int $exp){
-		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $exp, 0));
-		if($ev->isCancelled()){
-			$this->exp = $ev->getExp();
-			$this->calcExpLevel();
-			$this->updateExperience();
-			return true;
-		}
-		return false;
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->setTotalXp($exp);
 	}
 
+	/**
+	 * @deprecated Use Human::setXpLevel($level), this method will be removed in the future.
+	 */
 	public function setExpLevel(int $level){
-		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, 0, $level));
-		if(!$ev->isCancelled()){
-			$this->expLevel = $level;
-			$this->exp = $this->server->getExpectedExperience($level);
-			$this->updateExperience();
-			return true;
-		}
-		return false;
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->setXpLevel($level);
 	}
 
+	/**
+	 * @deprecated Use Human::getTotalXpRequirement($level), this method will be removed in the future.
+	 */
 	public function getExpectedExperience(){
-		return $this->server->getExpectedExperience($this->expLevel + 1);
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return self::getTotalXpRequirement($this->getXpLevel() + 1);
 	}
 
+	/**
+	 * @deprecated Use Human::getLevelXpRequirement($level), this method will be removed in the future.
+	 */
 	public function getLevelUpExpectedExperience(){
-		/*if($this->explevel < 16) return 2 * $this->explevel + 7;
-		elseif($this->explevel < 31) return 5 * $this->explevel - 38;
-		else return 9 * $this->explevel - 158;*/
-		return $this->getExpectedExperience() - $this->server->getExpectedExperience($this->expLevel);
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return self::getLevelXpRequirement($this->getLevel() + 1);
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function calcExpLevel(){
-		while($this->exp >= $this->getExpectedExperience()){
-			$this->expLevel++;
-		}
-		while($this->exp < $this->server->getExpectedExperience($this->expLevel - 1)){
-			$this->expLevel--;
-		}
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
 	}
 
+	/**
+	 * @deprecated Use Human::addXp($xp), this method will be removed in the future.
+	 */
 	public function addExperience(int $exp){
-		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $exp, 0, PlayerExperienceChangeEvent::ADD_EXPERIENCE));
-		if(!$ev->isCancelled()){
-			$this->exp = $this->exp + $ev->getExp();
-			$this->calcExpLevel();
-			$this->updateExperience();
-			return true;
-		}
-		return false;
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->addXp($exp);
 	}
 
+	/**
+	 * @deprecated Use Human::addXpLevel(), this method will be removed in the future.
+	 */
 	public function addExpLevel(int $level){
-		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, 0, $level, PlayerExperienceChangeEvent::ADD_EXPERIENCE));
-		if(!$ev->isCancelled()){
-			$this->expLevel = $this->expLevel + $ev->getExpLevel();
-			$this->exp = $this->server->getExpectedExperience($this->expLevel);
-			$this->calcExpLevel();
-			$this->updateExperience();
-			return true;
-		}
-		return false;
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->addXpLevel($level);
 	}
 
+	/**
+	 * @deprecated Use Human::getTotalXp(), this method will be removed in the future.
+	 */
 	public function getExp(){
-		return $this->exp;
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->getTotalXp();
 	}
 
+	/**
+	 * @deprecated Use Human::getXpLevel(), this method will be removed in the future.
+	 */
 	public function getExpLevel(){
-		return $this->expLevel;
-	}
-	
-	public function canPickupExp(): bool{
-		return microtime(true) - $this->expCooldown > 0.1;
-	}
-	
-	public function resetExpCooldown(){
-		$this->expCooldown = microtime(true);
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->getXpLevel();
 	}
 
+	/**
+	 * @deprecated Use Human::canPickupXp(), this method will be removed in the future.
+	 */
+	public function canPickupExp(): bool{
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		return $this->canPickupXp();
+	}
+
+	/**
+	 * @deprecated Use Human::resetXpCooldown(), this method will be removed in the future.
+	 */
+	public function resetExpCooldown(){
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
+		$this->resetXpCooldown();
+	}
+
+	/**
+	 * @deprecated
+	 */
 	public function updateExperience(){
-		if($this->getAttributeMap() instanceof AttributeMap){
-			$this->getAttributeMap()->getAttribute(Attribute::EXPERIENCE)->setValue(($this->exp - $this->server->getExpectedExperience($this->expLevel)) / ($this->getLevelUpExpectedExperience()), true, true);
-			$this->getAttributeMap()->getAttribute(Attribute::EXPERIENCE_LEVEL)->setValue($this->expLevel, true, true);
-		}
+		trigger_error("This method is deprecated, do not use it", E_USER_DEPRECATED);
 	}
 
 	/**
@@ -1015,10 +1011,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->spawnToAll();
 
 		$this->level->getWeather()->sendWeather($this);
-		if($this->server->expEnabled){
-			//$this->checkExpLevel();
-			$this->updateExperience();
-		}
+
 		$this->setHealth($this->getHealth());
 		if($this->server->foodEnabled) $this->setFood($this->getFood());
 		else $this->setFood(20);
@@ -1534,7 +1527,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 			if($entity instanceof Arrow and $entity->hadCollision){
 				$item = Item::get(Item::ARROW, $entity->getPotionId(), 1);
-				
+
 				$add = false;
 				if(!$this->server->allowInventoryCheats and !$this->isCreative()){
 					if(!$this->getFloatingInventory()->canAddItem($item) or !$this->inventory->canAddItem($item)){
@@ -1559,7 +1552,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$pk->eid = 0;
 				$pk->target = $entity->getId();
 				$this->dataPacket($pk);
-				
+
 				if($add){
 					$this->getFloatingInventory()->addItem(clone $item);
 				}
@@ -2126,19 +2119,15 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}else{
 			$nbt["NameTag"] = $this->username;
 		}
-		if(!isset($nbt->Hunger) or !isset($nbt->Experience) or !isset($nbt->ExpLevel) or !isset($nbt->Health) or !isset($nbt->MaxHealth)){
+		if(!isset($nbt->Hunger) or !isset($nbt->Health) or !isset($nbt->MaxHealth)){
 			$nbt->Hunger = new ShortTag("Hunger", 20);
-			$nbt->Experience = new LongTag("Experience", 0);
-			$nbt->ExpLevel = new LongTag("ExpLevel", 0);
 			$nbt->Health = new ShortTag("Health", 20);
 			$nbt->MaxHealth = new ShortTag("MaxHealth", 20);
 		}
 		$this->food = $nbt["Hunger"];
 		$this->setMaxHealth($nbt["MaxHealth"]);
 		Entity::setHealth(($nbt["Health"] <= 0) ? 20 : $nbt["Health"]);
-		$this->exp = ($nbt["Experience"] > 0) ? $nbt["Experience"] : 0;
-		$this->expLevel = ($nbt["ExpLevel"] >= 0) ? $nbt["ExpLevel"] : 0;
-		$this->calcExpLevel();
+
 		$this->gamemode = $nbt["playerGameType"] & 0x03;
 		if($this->server->getForceGamemode()){
 			$this->gamemode = $this->server->getGamemode();
@@ -2185,7 +2174,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 			return;
 		}
-		
+
 		if(!$this->isConnected()){
 			return;
 		}
@@ -2414,7 +2403,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 					break;
 				}
-				
+
 				if($this->isConnected()){
 					$this->onPlayerPreLogin();
 				}
@@ -2898,10 +2887,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						$this->removeAllEffects();
 						$this->setHealth($this->getMaxHealth());
 						$this->setFood(20);
-						if($this->server->expEnabled){
-							$this->updateExperience();
-						}
-
 						$this->starvationTick = 0;
 						$this->foodTick = 0;
 						$this->foodUsageTime = 0;
@@ -4022,10 +4007,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 
 		if($this->server->expEnabled and !$ev->getKeepExperience()){
-			$exp = $this->getExp();
-			$exp = min(100, $exp);
+			$exp = min(91, $this->getTotalXp()); //Max 7 levels of exp dropped
 			$this->getLevel()->spawnXPOrb($this->add(0, 0.2, 0), $exp);
-			$this->setExperienceAndLevel(0, 0);
+			$this->setTotalXp(0, true);
 		}
 
 		if($ev->getDeathMessage() != ""){

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -77,7 +77,7 @@ namespace pocketmine {
 	const CODENAME = "Kyrios";
 	const MINECRAFT_VERSION = "v0.15.4 alpha";
 	const MINECRAFT_VERSION_NETWORK = "0.15.4";
-	const GENISYS_API_VERSION = '1.9.1';
+	const GENISYS_API_VERSION = '1.9.2';
 
 	/*
 	 * Startup code. Do not look at it, it may harm you.

--- a/src/pocketmine/command/defaults/XpCommand.php
+++ b/src/pocketmine/command/defaults/XpCommand.php
@@ -55,21 +55,32 @@ class XpCommand extends VanillaCommand{
 		}
 		if($player instanceof Player){
 			$name = $player->getName();
-			if(strcasecmp(substr($args[0], -1), "L") == 0){			//Set Experience Level(with "L" after args[0])
-				$level = rtrim($args[0], "Ll");
-				if(is_numeric($level)){
-					$player->addXpLevel($level);
+			if(strcasecmp(substr($args[0], -1), "L") == 0){ //Set Experience Level(with "L" after args[0])
+				$level = (int) rtrim($args[0], "Ll");
+				if($level > 0){
+					$player->addXpLevel((int) $level);
+					$sender->sendMessage(new TranslationContainer("%commands.xp.success.levels", [$level, $name]));
 					$player->getLevel()->addSound(new ExpPickupSound($player, mt_rand(0, 1000))); //TODO: Find the level-up sound
-					$sender->sendMessage("Successfully added $level Level of experience to $name");
+					return true;
+				}elseif($level < 0){
+					$player->takeXpLevel((int) -$level);
+					$sender->sendMessage(new TranslationContainer("%commands.xp.success.negative.levels", [-$level, $name]));
+					return true;
 				}
-			}elseif(is_numeric($args[0])){											//Set Experience
-				$player->addXp($args[0]);
-				$player->getLevel()->addSound(new ExpPickupSound($player, mt_rand(0, 1000)));
-				$sender->sendMessage("Successfully added $args[0] of experience to $name");
 			}else{
-				$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
-				return false;
+				if(($xp = (int) $args[0]) > 0){ //Set Experience
+					$player->addXp((int) $args[0]);
+					$player->getLevel()->addSound(new ExpPickupSound($player, mt_rand(0, 1000)));
+					$sender->sendMessage(new TranslationContainer("%commands.xp.success", [$name, $args[0]]));
+					return true;
+				}elseif($xp < 0){ //Stupid, but this lines up with vanilla behaviour, so...
+					$sender->sendMessage(new TranslationContainer("%commands.xp.failure.withdrawXp"));
+					return true;
+				}
 			}
+			//This statement will only be reached if the command failed
+			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
+			return false;
 		}else{
 			$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.player.notFound"));
 			return false;

--- a/src/pocketmine/command/defaults/XpCommand.php
+++ b/src/pocketmine/command/defaults/XpCommand.php
@@ -44,32 +44,35 @@ class XpCommand extends VanillaCommand{
 			return true;
 		}
 
-		if(count($args) != 2){
-			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
-			return false;
+		if(count($args) < 2){
+			if($sender instanceof ConsoleCommandSender){
+				$sender->sendMessage("You must specify a target player in the console");
+				return true;
+			}
+			$player = $sender;
 		}else{
 			$player = $sender->getServer()->getPlayer($args[1]);
-			if($player instanceof Player){
-				$name = $player->getName();
-				if(strcasecmp(substr($args[0], -1), "L") == 0){			//Set Experience Level(with "L" after args[0])
-					$level = rtrim($args[0], "Ll");
-					if(is_numeric($level)){
-						$player->addExpLevel($level);
-						$player->getLevel()->addSound(new ExpPickupSound($player, mt_rand(0, 1000))); //TODO: Find the level-up sound
-						$sender->sendMessage("Successfully added $level Level of experience to $name");
-					}
-				}elseif(is_numeric($args[0])){											//Set Experience
-					$player->addExperience($args[0]);
-					$player->getLevel()->addSound(new ExpPickupSound($player, mt_rand(0, 1000)));
-					$sender->sendMessage("Successfully added $args[0] of experience to $name");
-				}else{
-					$sender->sendMessage("Argument error");
-					return false;
+		}
+		if($player instanceof Player){
+			$name = $player->getName();
+			if(strcasecmp(substr($args[0], -1), "L") == 0){			//Set Experience Level(with "L" after args[0])
+				$level = rtrim($args[0], "Ll");
+				if(is_numeric($level)){
+					$player->addXpLevel($level);
+					$player->getLevel()->addSound(new ExpPickupSound($player, mt_rand(0, 1000))); //TODO: Find the level-up sound
+					$sender->sendMessage("Successfully added $level Level of experience to $name");
 				}
+			}elseif(is_numeric($args[0])){											//Set Experience
+				$player->addXp($args[0]);
+				$player->getLevel()->addSound(new ExpPickupSound($player, mt_rand(0, 1000)));
+				$sender->sendMessage("Successfully added $args[0] of experience to $name");
 			}else{
-				$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.player.notFound"));
+				$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 				return false;
 			}
+		}else{
+			$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.player.notFound"));
+			return false;
 		}
 		return false;
 	}

--- a/src/pocketmine/entity/Attribute.php
+++ b/src/pocketmine/entity/Attribute.php
@@ -61,7 +61,7 @@ class Attribute{
 		self::addAttribute(self::FOLLOW_RANGE, "generic.followRange", 0.00, 2048.00, 16.00, false);
 		self::addAttribute(self::HUNGER, "player.hunger", 0.00, 20.00, 20.00);
 		self::addAttribute(self::ATTACK_DAMAGE, "generic.attackDamage", 0.00, 340282346638528859811704183484516925440.00, 1.00, false);
-		self::addAttribute(self::EXPERIENCE_LEVEL, "player.level", 0.00, 21863.00, 0.00);
+		self::addAttribute(self::EXPERIENCE_LEVEL, "player.level", 0.00, 2147483647.00, 0.00);
 		self::addAttribute(self::EXPERIENCE, "player.experience", 0.00, 1.00, 0.00);
 	}
 

--- a/src/pocketmine/entity/Attribute.php
+++ b/src/pocketmine/entity/Attribute.php
@@ -61,7 +61,7 @@ class Attribute{
 		self::addAttribute(self::FOLLOW_RANGE, "generic.followRange", 0.00, 2048.00, 16.00, false);
 		self::addAttribute(self::HUNGER, "player.hunger", 0.00, 20.00, 20.00);
 		self::addAttribute(self::ATTACK_DAMAGE, "generic.attackDamage", 0.00, 340282346638528859811704183484516925440.00, 1.00, false);
-		self::addAttribute(self::EXPERIENCE_LEVEL, "player.level", 0.00, 24791.00, 0.00);
+		self::addAttribute(self::EXPERIENCE_LEVEL, "player.level", 0.00, 21863.00, 0.00);
 		self::addAttribute(self::EXPERIENCE, "player.experience", 0.00, 1.00, 0.00);
 	}
 

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -24,6 +24,7 @@ namespace pocketmine\entity;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
 use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\event\player\PlayerExperienceChangeEvent;
 use pocketmine\inventory\FloatingInventory;
 use pocketmine\inventory\InventoryHolder;
 use pocketmine\inventory\InventoryType;
@@ -31,6 +32,7 @@ use pocketmine\inventory\PlayerInventory;
 use pocketmine\inventory\SimpleTransactionQueue;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\Item as ItemItem;
+use pocketmine\math\Math;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
@@ -77,6 +79,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	protected $totalXp = 0;
 	protected $xpSeed;
+	protected $xpCooldown = 0;
 
 	public function getSkinData(){
 		return $this->skin;
@@ -224,37 +227,188 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		return (int) $this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->getValue();
 	}
 
-	public function setXpLevel(int $level){
-		$this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->setValue($level);
+	public function setXpLevel(int $level) : bool{
+		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $level, $this->getXpProgress()));
+		if(!$ev->isCancelled()){
+			$this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->setValue($ev->getExpLevel());
+			return true;
+		}
+		return false;
+	}
+
+	public function addXpLevel(int $level) : bool{
+		return $this->setXpLevel($this->getXpLevel() + $level);
+	}
+
+	public function takeXpLevel(int $level) : bool{
+		return $this->setXpLevel($this->getXpLevel() - $level);
 	}
 
 	public function getXpProgress() : float{
 		return $this->attributeMap->getAttribute(Attribute::EXPERIENCE)->getValue();
 	}
 
-	public function setXpProgress(float $progress){
+	public function setXpProgress(float $progress) : bool{
 		$this->attributeMap->getAttribute(Attribute::EXPERIENCE)->setValue($progress);
+		return true;
 	}
 
-	public function getTotalXp() : float{
+	public function getTotalXp() : int{
 		return $this->totalXp;
 	}
 
+	/**
+	 * Changes the total exp of a player
+	 *
+	 * @param int $xp
+	 * @param bool $syncLevel This will reset the level to be in sync with the total. Usually you don't want to do this,
+	 *                        because it'll mess up use of xp in anvils and enchanting tables.
+	 *
+	 * @return bool
+	 */
+	public function setTotalXp(int $xp, bool $syncLevel = false) : bool{
+		$xp &= 0x7fffffff;
+		if($xp === $this->totalXp){
+			return false;
+		}
+		if(!$syncLevel){
+			$level = $this->getXpLevel();
+			$diff = $xp - $this->totalXp + $this->getFilledXp();
+			if($diff > 0){
+				while($diff > ($v = self::getLevelXpRequirement($level))){
+					$diff -= $v;
+					if(++$level >= 21863){
+						$diff = $v; //fill exp bar
+						break;
+					}
+				}
+			}else{
+				while($diff < ($v = self::getLevelXpRequirement($level - 1))){
+					$diff += $v;
+					if(--$level <= 0){
+						$diff = 0;
+						break;
+					}
+				}
+			}
+			$progress = ($diff / $v);
+		}else{
+			$values = self::getLevelFromXp($xp);
+			$level = $values[0];
+			$progress = $values[1];
+		}
+
+		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $level, $progress));
+		if(!$ev->isCancelled()){
+			$this->setXpLevel($ev->getExpLevel());
+			$this->setXpProgress($ev->getProgress());
+			return true;
+		}
+		return false;
+	}
+
+	public function addXp(int $xp, bool $syncLevel = false) : bool{
+		return $this->setTotalXp($this->totalXp + $xp, $syncLevel);
+	}
+
+	public function takeXp(int $xp, bool $syncLevel = false) : bool{
+		return $this->setTotalXp($this->totalXp - $xp, $syncLevel);
+	}
+
 	public function getRemainderXp() : int{
-		return $this->getTotalXp() - self::getTotalXpForLevel($this->getXpLevel());
+		return self::getLevelXpRequirement($this->getXpLevel()) - $this->getFilledXp();
+	}
+
+	public function getFilledXp() : int{
+		return self::getLevelXpRequirement($this->getXpLevel()) * $this->getXpProgress();
 	}
 
 	public function recalculateXpProgress() : float{
-		$this->setXpProgress($this->getRemainderXp() / self::getTotalXpForLevel($this->getXpLevel()));
+		$this->setXpProgress($this->getRemainderXp() / self::getLevelXpRequirement($this->getXpLevel()));
 	}
 
-	public static function getTotalXpForLevel(int $level) : int{
+	public function getXpSeed() : int{
+		//TODO: use this for randomizing enchantments in enchanting tables
+		return $this->xpSeed;
+	}
+
+	public function resetXpCooldown(){
+		$this->xpCooldown = microtime(true);
+	}
+
+	public function canPickupXp() : bool{
+		return microtime(true) - $this->xpCooldown > 0.5;
+	}
+
+	/**
+	 * Returns the total amount of exp required to reach the specified level.
+	 *
+	 * @param int $level
+	 *
+	 * @return int
+	 */
+	public static function getTotalXpRequirement(int $level) : int{
 		if($level <= 16){
-			return $level ** 2 + $level * 6;
-		}elseif($level < 32){
-			return $level ** 2 * 2.5 - 40.5 * $level + 360;
+			return ($level ** 2) + (6 * $level);
+		}elseif($level <= 31){
+			return (2.5 * ($level ** 2)) - (40.5 * $level) + 360;
+		}elseif($level <= 21863){
+			return (4.5 * ($level ** 2)) - (162.5 * $level) + 2220;
 		}
-		return $level ** 2 * 4.5 - 162.5 * $level + 2220;
+		return PHP_INT_MAX; //prevent float returns for invalid levels on 32-bit systems
+	}
+
+	/**
+	 * Returns the amount of exp required to complete the specified level.
+	 *
+	 * @param int $level
+	 *
+	 * @return int
+	 */
+	public static function getLevelXpRequirement(int $level) : int{
+		if($level <= 16){
+			return (2 * $level) + 7;
+		}elseif($level <= 31){
+			return (5 * $level) - 38;
+		}elseif($level <= 21863){
+			return (9 * $level) - 158;
+		}
+		return PHP_INT_MAX;
+	}
+
+	/**
+	 * Converts a quantity of exp into a level and a progress percentage
+	 *
+	 * @param int $xp
+	 *
+	 * @return int[]
+	 */
+	public static function getLevelFromXp(int $xp) : array{
+		$xp &= 0x7fffffff;
+
+		/** These values are correct up to and including level 16 */
+		$a = 1;
+		$b = 6;
+		$c = -$xp;
+		if($xp > self::getTotalXpRequirement(16)){
+			/** Modify the coefficients to fit the relevant equation */
+			if($xp <= self::getTotalXpRequirement(31)){
+				/** Levels 16-31 */
+				$a = 2.5;
+				$b = -40.5;
+				$c += 360;
+			}else{
+				/** Level 32+ */
+				$a = 4.5;
+				$b = -162.5;
+				$c += 2220;
+			}
+		}
+
+		$answer = max(Math::solveQuadratic($a, $b, $c)); //Use largest result value
+		$level = floor($answer);
+		$progress = $answer - $level;
+		return [$level, $progress];
 	}
 
 	public function getInventory(){
@@ -327,26 +481,24 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		}*/
 
 		if(!isset($this->namedtag->XpLevel) or !($this->namedtag->XpLevel instanceof IntTag)){
-			$this->namedtag->XpLevel = new IntTag("XpLevel", $this->getXpLevel());
-		}else{
-			$this->setXpLevel($this->namedtag["XpLevel"]);
+			$this->namedtag->XpLevel = new IntTag("XpLevel", 0);
 		}
+		$this->setXpLevel($this->namedtag["XpLevel"]);
 
 		if(!isset($this->namedtag->XpP) or !($this->namedtag->XpP instanceof FloatTag)){
-			$this->namedtag->XpP = new FloatTag("XpP", $this->getXpProgress());
+			$this->namedtag->XpP = new FloatTag("XpP", 0);
 		}
+		$this->setXpProgress($this->namedtag["XpP"]);
 
 		if(!isset($this->namedtag->XpTotal) or !($this->namedtag->XpTotal instanceof IntTag)){
-			$this->namedtag->XpTotal = new IntTag("XpTotal", $this->totalXp);
-		}else{
-			$this->totalXp = $this->namedtag["XpTotal"];
+			$this->namedtag->XpTotal = new IntTag("XpTotal", 0);
 		}
+		$this->totalXp = $this->namedtag["XpTotal"];
 
 		if(!isset($this->namedtag->XpSeed) or !($this->namedtag->XpSeed instanceof IntTag)){
-			$this->namedtag->XpSeed = new IntTag("XpSeed", $this->xpSeed ?? ($this->xpSeed = mt_rand(PHP_INT_MIN, PHP_INT_MAX)));
-		}else{
-			$this->xpSeed = $this->namedtag["XpSeed"];
+			$this->namedtag->XpSeed = new IntTag("XpSeed", mt_rand(PHP_INT_MIN, PHP_INT_MAX));
 		}
+		$this->xpSeed = $this->namedtag["XpSeed"];
 	}
 
 	public function getAbsorption() : int{
@@ -465,6 +617,11 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 				"Name" => new StringTag("Name", $this->getSkinId())
 			]);
 		}
+		$this->namedtag->XpLevel = new IntTag("XpLevel", $this->getXpLevel());
+		$this->namedtag->XpTotal = new IntTag("XpTotal", $this->getTotalXp());
+		$this->namedtag->XpP = new FloatTag("XpP", $this->getXpProgress());
+		$this->namedtag->XpSeed = new IntTag("XpSeed", $this->getXpSeed());
+
 	}
 
 	public function spawnTo(Player $player){

--- a/src/pocketmine/entity/XPOrb.php
+++ b/src/pocketmine/entity/XPOrb.php
@@ -71,7 +71,7 @@ class XPOrb extends Entity{
 		$minDistance = PHP_INT_MAX;
 		$target = null;
 		foreach($this->getViewers() as $p){
-			if(!$p->isSpectator()){
+			if(!$p->isSpectator() and $p->isAlive()){
 				if(($dist = $p->distance($this)) < $minDistance and $dist < $this->range){
 					$target = $p;
 					$minDistance = $dist;
@@ -105,15 +105,15 @@ class XPOrb extends Entity{
 			}
 
 			if($minDistance <= 1.3){
-				if($this->getLevel()->getServer()->expEnabled and $target->canPickupExp()){
+				if($this->getLevel()->getServer()->expEnabled and $target->canPickupXp()){
 					$this->getLevel()->getServer()->getPluginManager()->callEvent($ev = new PlayerPickupExpOrbEvent($target, $this->getExperience()));
 					if(!$ev->isCancelled()){
 						$this->kill();
 						$this->close();
 						if($this->getExperience() > 0){
-							$target->addExperience($this->getExperience());
-							$target->resetExpCooldown();
 							$this->level->addSound(new ExpPickupSound($target, mt_rand(0, 1000)));
+							$target->addXp($this->getExperience());
+							$target->resetXpCooldown();
 						}
 					}
 				}

--- a/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
+++ b/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
@@ -22,43 +22,53 @@
 namespace pocketmine\event\player;
 
 use pocketmine\event\Cancellable;
-use pocketmine\Player;
+use pocketmine\entity\Human;
 
 class PlayerExperienceChangeEvent extends PlayerEvent implements Cancellable{
+	
+	/** @deprecated */
 	const ADD_EXPERIENCE = 0;
 	const SET_EXPERIENCE = 1;
 	
 	public static $handlerList = null;
 	
-	public $exp;
+	public $progress;
 	public $expLevel;
-	public $action;
 
-	public function __construct(Player $player, $exp, $expLevel, $action = PlayerExperienceChangeEvent::SET_EXPERIENCE){
-		$this->exp = $exp;
+	public function __construct(Human $player, int $expLevel, float $progress){
+		$this->progress = $progress;
 		$this->expLevel = $expLevel;
-		$this->action = $action;
 		$this->player = $player;
 	}
 	
+	/**
+	 * @deprecated This is redundant, and will be removed in the future.
+	 */
 	public function getAction(){
-		return $this->action;
+		return self::SET_EXPERIENCE;
 	}
-	
-	public function getExp(){
-		return $this->exp;
-	}
-	
+
 	public function getExpLevel(){
 		return $this->expLevel;
 	}
-	
-	public function setExp($exp){
-		$this->exp = $exp;
-	}
-	
+
 	public function setExpLevel($level){
 		$this->expLevel = $level;
 	}
 
+	public function getProgress(): float{
+		return $this->progress;
+	}
+	
+	public function setProgress(float $progress){
+		$this->progress = $progress; //errors will be handled internally anyway
+	}
+
+	public function getExp(){
+		return Human::getLevelXpRequirement($this->level) * $this->progress;
+	}
+
+	public function setExp($exp){
+		$this->progress = $exp / Human::getLevelXpRequirement($this->level);
+	}
 }

--- a/src/pocketmine/inventory/AnvilInventory.php
+++ b/src/pocketmine/inventory/AnvilInventory.php
@@ -53,10 +53,10 @@ class AnvilInventory extends TemporaryInventory{
 			return false;
 		}
 
-		if($player->getExpLevel() < $resultItem->getRepairCost()){ //Not enough exp
+		if($player->getXpLevel() < $resultItem->getRepairCost()){ //Not enough exp
 			return false;
 		}
-		$player->setExpLevel($player->getExpLevel() - $resultItem->getRepairCost());
+		$player->takeXpLevel($resultItem->getRepairCost());
 		
 		$this->clearAll();
 		if(!$player->getServer()->allowInventoryCheats and !$player->isCreative()){
@@ -80,7 +80,6 @@ class AnvilInventory extends TemporaryInventory{
 	}
 
 	public function onClose(Player $who){
-		$who->updateExperience();
 		parent::onClose($who);
 
 		$this->getHolder()->getLevel()->dropItem($this->getHolder()->add(0.5, 0.5, 0.5), $this->getItem(0));

--- a/src/pocketmine/inventory/EnchantInventory.php
+++ b/src/pocketmine/inventory/EnchantInventory.php
@@ -226,7 +226,7 @@ class EnchantInventory extends TemporaryInventory{
 			for($i = 0; $i < 3; $i++){
 				if($this->checkEnts($enchantments, $this->entries[$i]->getEnchantments())){
 					$lapis = $this->getItem(1);
-					$level = $who->getExpLevel();
+					$level = $who->getXpLevel();
 					$cost = $this->entries[$i]->getCost();
 					if($lapis->getId() == Item::DYE and $lapis->getDamage() == Dye::BLUE and $lapis->getCount() > $i and $level >= $cost){
 						foreach($enchantments as $enchantment){
@@ -235,7 +235,7 @@ class EnchantInventory extends TemporaryInventory{
 						$this->setItem(0, $result);
 						$lapis->setCount($lapis->getCount() - $i - 1);
 						$this->setItem(1, $lapis);
-						$who->setExpLevel($level - $i - 1);
+						$who->takeXpLevel($i + 1);
 						break;
 					}
 				}

--- a/src/pocketmine/lang/locale/eng.ini
+++ b/src/pocketmine/lang/locale/eng.ini
@@ -197,7 +197,6 @@ commands.help.header=--- Showing help page {%0} of {%1} (/help <page>) ---
 commands.help.usage=/help [page|command name]
 commands.message.usage=/tell <player> <private message ...>
 commands.message.sameTarget=You can't send a private message to yourself!
-commands.xp.usage=/xp <Experience or ExprLevel+L> <player>
 
 commands.difficulty.usage=/difficulty <new difficulty>
 commands.difficulty.success=Set game difficulty to {%0}
@@ -208,6 +207,12 @@ commands.setworldspawn.usage=/setworldspawn [<x> <y> <z>]
 commands.setworldspawn.success=Set the world spawn point to ({%0}, {%1}, {%2})
 
 commands.summon.usage=/summon [entity] [<x> <y> <z>] [NBTTag]
+
+commands.xp.failure.withdrawXp=Cannot give player negative experience points
+commands.xp.success=Given {%0} experience to {%1}
+commands.xp.success.levels=Given {%0} levels to {%1}
+commands.xp.success.negative.levels=Taken {%0} levels from {%1}
+commands.xp.usage=/xp <amount> [player] OR /xp <amount>L [player]
 
 # -------------------- PocketMine language files, only for console --------------------
 pocketmine.data.playerNotFound=Player data not found for "{%0}", creating new profile

--- a/src/pocketmine/math/Math.php
+++ b/src/pocketmine/math/Math.php
@@ -40,4 +40,13 @@ abstract class Math{
 	public static function clamp($value, $low, $high){
 		return min($high, max($low, $value));
 	}
+	
+	public static function solveQuadratic($a, $b, $c): array{
+		$x[0] = (-$b + sqrt($b ** 2 - 4 * $a * $c)) / (2 * $a);
+		$x[1] = (-$b - sqrt($b ** 2 - 4 * $a * $c)) / (2 * $a);
+		if($x[0] == $x[1]){
+			return [$x[0]];
+		}
+		return $x;
+	}
 }

--- a/src/pocketmine/resources/genisys_chs.yml
+++ b/src/pocketmine/resources/genisys_chs.yml
@@ -2,7 +2,7 @@
 
 #配置文件版本
 config:
- version: 20
+ version: 21
  
 level:
  #设置是否变换天气
@@ -42,8 +42,6 @@ nether:
  level-name: "nether"
  
 server:
- #经验数据预生成，0不启用
- experience-cache: 65535
  #是否允许生成铁傀儡
  allow-iron-golem: false
  #是否允许生成雪傀儡

--- a/src/pocketmine/resources/genisys_eng.yml
+++ b/src/pocketmine/resources/genisys_eng.yml
@@ -2,7 +2,7 @@
 
 #Version of this file
 config:
- version: 20
+ version: 21
 
 level:
  #Set if turn on the weather system
@@ -42,8 +42,6 @@ nether:
  level-name: "nether"
  
 server:
- #Pregenerate the experience data，0=disabled
- experience-cache: 65535
  #Choose if spawning iron golem is allowed
  allow-iron-golem: false
  #Choose if spawning snow golem is allowed

--- a/src/pocketmine/resources/genisys_kor.yml
+++ b/src/pocketmine/resources/genisys_kor.yml
@@ -2,7 +2,7 @@
 
 #Version 파일의 버전
 config:
- version: 20
+ version: 21
 
 level:
  #날씨 시스템을 켜는 경우 설정하세요
@@ -42,8 +42,6 @@ nether:
  level-name: "nether"
  
 server:
- #경험치 데이터를 미리 생성합니다，0=비활성화
- experience-cache: 65535
  #철 골램을 생성하는 것이 허용된 경우 고르세요
  allow-iron-golem: false
  #눈 골렘을 생성하는 것이 허용된 경우 고르세요

--- a/src/pocketmine/resources/genisys_vie.yml
+++ b/src/pocketmine/resources/genisys_vie.yml
@@ -2,7 +2,7 @@
 
 #Phiên bản file cài đặt
 config:
- version: 20
+ version: 21
 
 level:
  #Chỉnh nếu muốn bật/tắt thời tiết (true/false)
@@ -42,8 +42,6 @@ nether:
  level-name: "nether"
  
 server:
- #Tái tạo lại hệ thống điểm kinh nghiệm，0=hủy bỏ chế độ
- experience-cache: 65535
  #Bật/tắt nếu muốn thêm Iron Golem vào server (true/false)
  allow-iron-golem: false
  #Bật/tắt nếu muốn thêm Snow Golem vào server (true/false)

--- a/src/pocketmine/resources/genisys_zho.yml
+++ b/src/pocketmine/resources/genisys_zho.yml
@@ -2,7 +2,7 @@
 
 #設定檔案版本
 config:
- version: 20
+ version: 21
 
 level:
  #設定是否變換天氣
@@ -42,8 +42,6 @@ nether:
  level-name: "nether"
  
 server:
- #經驗數據預生成，0不啟用
- experience-cache: 65535
  #是否允許生成鐵傀儡
  allow-iron-golem: false
  #是否允許生成雪傀儡


### PR DESCRIPTION
### Description

Title sums it up, and #1930 provides a detailed description of the issue. This fixes the **second** exp-related memory leak I've happened onto.
### Reason to modify
- Think twice before modifying: is it the best way? will it break things?
  - It's sure as hell better than the old way of doing it.
- Have you made sure that there is actually a problem before trying to fix it?
  - Hell yes. This replaces some of the most idiotic programming I've seen in years.
- Explain the logic behind your changes - WHY and HOW what you have done works
  - Removed the appalling code causing the memory leak and replaced it with something more efficient.

This PR includes some changes to the API for experience. Various xp-related methods in Player.php have been deprecated in favour of alternatives in Human.php which were already present and waiting to be used. I have bumped the Genisys API to 1.9.2 in response.

The property `experience-cache` has been removed from genisys.yml.
#### Fixes
- Fixed #1930 - excessively high levels of exp in a player caused a huge memory leak which would crash the server in seconds
- Fixed a bug where players would pickup exp even when dead, resulting in apparent loss of dropped exp.
#### Changes
- Various methods in Player.php  and Server.php relating to exp have been deprecated or removed. See the diff for changes.
- Now using the PocketMine API for exp in Human.php (never implemented before now).
### Tests & Reviews

I've tested this in various circumstances, and confirmed that the issues mentioned above no longer occur. I have not however verified with Synapse.
