### PR TITLE
Add warning for xdebug on startup

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -415,6 +415,15 @@ namespace pocketmine {
 			++$errors;
 		}
 	}
+	
+	if(extension_loaded("xdebug")){
+		$logger->warning("
+
+
+	You are running PocketMine with xdebug enabled. This has a major impact on performance.
+
+		");
+	}
 
 	if(!extension_loaded("curl")){
 		$logger->critical("Unable to find the cURL extension.");


### PR DESCRIPTION
### Description
I intended to commit this directly, but either GitHub has screwed up the branch protection or somebody has tampered with the settings, because I can't commit to master.

This PR adds a warning for xdebug on startup.

### Reason to modify
- xdebug has a huge impact on runtime performance. Having it loaded and not realising could cause server owners lots of grief.

### Tests & Reviews
I have tested the code and it works.