### PR TITLE
Fixed start.cmd on windows, when using system PHP.

### DIFF
--- a/start.cmd
+++ b/start.cmd
@@ -32,5 +32,9 @@ if exist Genisys*.phar (
 if exist bin\mintty.exe (
 	start "" bin\mintty.exe -o Columns=88 -o Rows=32 -o AllowBlinking=0 -o FontQuality=3 -o Font="Consolas" -o FontHeight=10 -o CursorType=0 -o CursorBlinks=1 -h error -t "Genisys" -w max %PHP_BINARY% %POCKETMINE_FILE% --enable-ansi %*
 ) else (
-	%PHP_BINARY% -c bin\php %POCKETMINE_FILE% %*
+	if exist bin\php (
+		%PHP_BINARY% -c bin\php %POCKETMINE_FILE% %*
+	) else (
+		%PHP_BINARY% %POCKETMINE_FILE% %*
+	)
 )


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
I'm tried to clone Genisys and just run it. I'm get this error:
```
[CRITICAL] Unable to find the pthreads extension.
[CRITICAL] Please use the installer provided on the homepage.
```

I'm has pthreads in system PHP, but if use `-c bin\php` when this folder isn't exists, php will not use extensions.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Fix this error.

### Tests & Reviews
<!-- Uncomment based on the situation -->

I have tested the code and it works.

<!-- Please review things below: -->

