### PR TITLE
Typo fix

### DIFF
--- a/src/pocketmine/command/CommandReader.php
+++ b/src/pocketmine/command/CommandReader.php
@@ -85,7 +85,7 @@ class CommandReader extends Thread{
 	public function quit(){
 		$this->shutdown();
 		// Windows sucks
-		if(Utils::getOS() != "win"){
+		if(Utils::getOS() !== "win"){
 			parent::quit();
 		}
 	}


### PR DESCRIPTION
### Description
This PR fixes a typo with "!=" that should be "!==".


### Reason to modify
Fixing always a false value.

### Tests & Reviews
<!-- Uncomment based on the situation -->

I have not tested the code.

<!-- Please review things below: -->

