### PR TITLE
add isFirstLogin function to synapse player

### DIFF
--- a/src/synapse/Player.php
+++ b/src/synapse/Player.php
@@ -303,4 +303,8 @@ class Player extends PMPlayer{
 		}
 		$this->interface->putPacket($this, $packet, $needACK, true);
 	}
+	
+	public function isFirstLogin(){
+		return $this->isFirstTimeLogin;
+	}
 }


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Adding the isFirstLogin function to synapse player

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
This will allow us to check whether it is the player's first login to the Synapse/Nemisys proxy or not. This would work well for global login plugins or some other things

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->

<!-- Please review things below: -->
Common sense says this works, but just letting you know I have not tested it.

