### PR TITLE
Fix waterlily setting off anticheat

### DIFF
--- a/src/pocketmine/block/WaterLily.php
+++ b/src/pocketmine/block/WaterLily.php
@@ -29,7 +29,7 @@ use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
 
-class WaterLily extends Flowable{
+class WaterLily extends Transparent{
 
 	protected $id = self::WATER_LILY;
 
@@ -38,7 +38,7 @@ class WaterLily extends Flowable{
 	}
 
 	public function isSolid(){
-		return false;
+		return true;
 	}
 
 	public function getName() : string{


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
WaterLily's would cause you to be pulled to the ground until you were off them, disallowing you to jump on them. A WaterLily IS a block that can NOT be passed through, so it should be Transparent, rather than Flowable.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Read above ^^^

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->

<!-- Please review things below: -->
This has not been tested, but I know this will work, WaterLily's can't be passed through, so this makes sense. (Please don't roast me if I am incorrect though, lmao)
