### PR TITLE
Fix Undefined Offset Notice coming from XpCommand

### DIFF
--- a/src/pocketmine/command/defaults/XpCommand.php
+++ b/src/pocketmine/command/defaults/XpCommand.php
@@ -55,6 +55,10 @@ class XpCommand extends VanillaCommand{
 		}
 		if($player instanceof Player){
 			$name = $player->getName();
+			if(count($args) < 1){
+				$player->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
+				return false;
+			}
 			if(strcasecmp(substr($args[0], -1), "L") == 0){ //Set Experience Level(with "L" after args[0])
 				$level = (int) rtrim($args[0], "Ll");
 				if($level > 0){


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
When running the `xp` as a player with no argument an undefined offset notice would appear in the console.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
I have tested this and it doesn't break anything, there was an undefined offset notice (read above). 


### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->
This has been tested and works.
<!-- Please review things below: -->