### PR TITLE
Enchantment Name Support - EnchantCommand

### DIFF
--- a/src/pocketmine/command/defaults/EnchantCommand.php
+++ b/src/pocketmine/command/defaults/EnchantCommand.php
@@ -63,11 +63,11 @@ class EnchantCommand extends VanillaCommand{
 
 		$enchantment = Enchantment::getEnchantment($enchantId);
 		if($enchantment->getId() === Enchantment::TYPE_INVALID){
-		  $enchantment = Enchantment::getEnchantmentByName($enchantId);
-		  if($enchantment->getId() === Enchantment::TYPE_INVALID){
-			$sender->sendMessage(new TranslationContainer("commands.enchant.notFound", [$enchantment->getId()]));
-			return true;
-		  }
+			$enchantment = Enchantment::getEnchantmentByName($enchantId);
+			if($enchantment->getId() === Enchantment::TYPE_INVALID){
+	    		$sender->sendMessage(new TranslationContainer("commands.enchant.notFound", [$enchantment->getId()]));
+				return true;
+			}
 		}
 
 		$enchantment->setLevel($enchantLevel);

--- a/src/pocketmine/command/defaults/EnchantCommand.php
+++ b/src/pocketmine/command/defaults/EnchantCommand.php
@@ -58,13 +58,16 @@ class EnchantCommand extends VanillaCommand{
 			return true;
 		}
 
-		$enchantId = (int) $args[1];
+		$enchantId = $args[1];
 		$enchantLevel = isset($args[2]) ? (int) $args[2] : 1;
 
 		$enchantment = Enchantment::getEnchantment($enchantId);
 		if($enchantment->getId() === Enchantment::TYPE_INVALID){
-			$sender->sendMessage(new TranslationContainer("commands.enchant.notFound", [$enchantId]));
+		  $enchantment = Enchantment::getEnchantmentByName($enchantId);
+		  if($enchantment->getId() === Enchantment::TYPE_INVALID){
+			$sender->sendMessage(new TranslationContainer("commands.enchant.notFound", [$enchantment->getId()]));
 			return true;
+		  }
 		}
 
 		$enchantment->setLevel($enchantLevel);

--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -200,7 +200,7 @@ class Enchantment{
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_FISHING_" . strtoupper($name))); 
 		}
 		else{
-		  return new Enchantment(self::TYPE_INVALID, "unknown", 0, 0, 0);
+			return new Enchantment(self::TYPE_INVALID, "unknown", 0, 0, 0);
 	    }
 	}
 

--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -180,11 +180,28 @@ class Enchantment{
 		return new Enchantment(self::TYPE_INVALID, "unknown", 0, 0, 0);
 	}
 
-	public static function getEffectByName($name){
+	public static function getEnchantmentByName($name){
 		if(defined(Enchantment::class . "::TYPE_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_" . strtoupper($name)));
 		}
-		return null;
+		else if(defined(Enchantment::class . "::TYPE_WEAPON_" . strtoupper($name))){
+			return self::getEnchantment(constant(Enchantment::class . "::TYPE_WEAPON_" . strtoupper($name))); 
+		}
+		else if(defined(Enchantment::class . "::TYPE_ARMOR_" . strtoupper($name))){
+			return self::getEnchantment(constant(Enchantment::class . "::TYPE_ARMOR_" . strtoupper($name))); 
+		}
+		else if(defined(Enchantment::class . "::TYPE_MINING_" . strtoupper($name))){
+			return self::getEnchantment(constant(Enchantment::class . "::TYPE_MINING_" . strtoupper($name))); 
+		}
+		else if(defined(Enchantment::class . "::TYPE_BOW_" . strtoupper($name))){
+			return self::getEnchantment(constant(Enchantment::class . "::TYPE_BOW_" . strtoupper($name))); 
+		}
+		else if(defined(Enchantment::class . "::TYPE_FISHING_" . strtoupper($name))){
+			return self::getEnchantment(constant(Enchantment::class . "::TYPE_FISHING_" . strtoupper($name))); 
+		}
+		else{
+		  return new Enchantment(self::TYPE_INVALID, "unknown", 0, 0, 0);
+	    }
 	}
 
 	public static function getEnchantAbility(Item $item){

--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -183,23 +183,17 @@ class Enchantment{
 	public static function getEnchantmentByName($name){
 		if(defined(Enchantment::class . "::TYPE_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_" . strtoupper($name)));
-		}
-		else if(defined(Enchantment::class . "::TYPE_WEAPON_" . strtoupper($name))){
+		}elseif(defined(Enchantment::class . "::TYPE_WEAPON_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_WEAPON_" . strtoupper($name))); 
-		}
-		else if(defined(Enchantment::class . "::TYPE_ARMOR_" . strtoupper($name))){
+		}elseif(defined(Enchantment::class . "::TYPE_ARMOR_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_ARMOR_" . strtoupper($name))); 
-		}
-		else if(defined(Enchantment::class . "::TYPE_MINING_" . strtoupper($name))){
+		}elseif(defined(Enchantment::class . "::TYPE_MINING_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_MINING_" . strtoupper($name))); 
-		}
-		else if(defined(Enchantment::class . "::TYPE_BOW_" . strtoupper($name))){
+		}elseif(defined(Enchantment::class . "::TYPE_BOW_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_BOW_" . strtoupper($name))); 
-		}
-		else if(defined(Enchantment::class . "::TYPE_FISHING_" . strtoupper($name))){
+		}elseif(defined(Enchantment::class . "::TYPE_FISHING_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_FISHING_" . strtoupper($name))); 
-		}
-		else{
+		}else{
 			return new Enchantment(self::TYPE_INVALID, "unknown", 0, 0, 0);
 	    }
 	}


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
This PR adds support for Enchantment names when using the enchant command.
Previously when using the enchant command `/enchant ImagicalGamer smite 1` the command returned with a  Unknown Enchantment message. Now when running the same command checks for enchantment names as well as enchantment ID's.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
Yes this is a good way to fix things.
There is no real issue, this is to help users who don't know every enchantment ID.
I modified an existing function to make it work correctly.

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->
I have tested this code and it works.
<!-- Please review things below: -->

* Enchantment Name Support 1/2

* Enchantment Name Support 2/2