### PR TITLE
Minecraft 0.15.10 Support

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -75,8 +75,8 @@ namespace pocketmine {
 	const VERSION = ""; //will be set by CI to a git hash
 	const API_VERSION = "2.0.0";
 	const CODENAME = "Kyrios";
-	const MINECRAFT_VERSION = "v0.15.9 alpha";
-	const MINECRAFT_VERSION_NETWORK = "0.15.9";
+	const MINECRAFT_VERSION = "v0.15.10 alpha";
+	const MINECRAFT_VERSION_NETWORK = "0.15.10";
 	const GENISYS_API_VERSION = '1.9.3';
 
 	/*

--- a/src/pocketmine/network/protocol/Info.php
+++ b/src/pocketmine/network/protocol/Info.php
@@ -30,8 +30,8 @@ interface Info{
 	/**
 	 * Actual Minecraft: PE protocol version
 	 */
-	const CURRENT_PROTOCOL = 83;
-	const ACCEPTED_PROTOCOLS = [83];
+	const CURRENT_PROTOCOL = 84;
+	const ACCEPTED_PROTOCOLS = [83, 84];
 
 	const LOGIN_PACKET = 0x01;
 	const PLAY_STATUS_PACKET = 0x02;


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
It adds support for 0.15.10

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
You can't play on 0.15.10 without it
### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->
I have tested the code and it works
<!-- Please review things below: -->
![minecraft - pocket edition_20161004_234201](https://cloud.githubusercontent.com/assets/17461354/19100437/c7bd78c6-8a8c-11e6-9d1d-a648c2aa86b2.png)

