### PR TITLE
Fix hopper item duplication

### DIFF
--- a/src/pocketmine/tile/Hopper.php
+++ b/src/pocketmine/tile/Hopper.php
@@ -99,7 +99,7 @@ class Hopper extends Spawnable implements InventoryHolder, Container, Nameable{
 		$area = clone $this->getBlock()->getBoundingBox(); //Area above hopper to draw items from
 		$area->maxY = ceil($area->maxY) + 1; //Account for full block above, not just 1 + 5/8
 		foreach($this->getLevel()->getChunkEntities($this->getBlock()->x >> 4, $this->getBlock()->z >> 4) as $entity){
-			if(!($entity instanceof DroppedItem)){
+			if(!($entity instanceof DroppedItem) or !$entity->isAlive()){
 				continue;
 			}
 			if(!$entity->boundingBox->intersectsWith($area)){


### PR DESCRIPTION
### Description
Fixes hopper item duplication glitches.

This prevents items being pulled/sucked into multiple hoppers on the same tick by checking if their death has already been 'scheduled' for the next tick.

### Reason to modify
This bug is well known and very annoying.

### Tests & Reviews
Tested thoroughly on my personal test server.