### PR TITLE
Remove dead Jenkins CI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ __Feature-rich server software for Minecraft: Pocket Edition & Windows 10 Editio
 [![PayPal donate button](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.me/PeratX)
 [![Travis-CI](https://img.shields.io/travis/iTXTech/Genisys/master.svg)](https://travis-ci.org/iTXTech/Genisys)
 [![GitLab CI](https://gitlab.com/itxtech/genisys/badges/master/build.svg)](https://gitlab.com/itxtech/genisys/pipelines?scope=branches)
-[![Jenkins](https://img.shields.io/jenkins/s/https/ci.itxtech.org/Genisys.svg)](https://ci.itxtech.org/job/Genisys/lastSuccessfulBuild/)
 
 ## NOTICE: 0.16 IS NOT SUPPORTED YET. Read [#1807](https://github.com/iTXTech/Genisys/issues/1807) for further information.
 


### PR DESCRIPTION
### Description
To remove a dead Jenkins link in the readme


### Reason to modify
I have modified this because the link does not lead anywhere, therefore is pointless and needs removing.


