### PR TITLE
Removed unnecessary message in ListCommand.php

### DIFF
--- a/src/pocketmine/command/defaults/ListCommand.php
+++ b/src/pocketmine/command/defaults/ListCommand.php
@@ -22,6 +22,7 @@
 namespace pocketmine\command\defaults;
 
 use pocketmine\command\CommandSender;
+use pocketmine\command\ConsoleCommandSender;
 use pocketmine\event\TranslationContainer;
 use pocketmine\Player;
 
@@ -51,8 +52,11 @@ class ListCommand extends VanillaCommand{
 				++$onlineCount;
 			}
 		}
-
+		
 		$sender->sendMessage(new TranslationContainer("commands.players.list", [$onlineCount, $sender->getServer()->getMaxPlayers()]));
+		if(($sender instanceof ConsoleCommandSender) and ($onlineCount === 0){
+			return false;
+		}
 		$sender->sendMessage(substr($online, 0, -2));
 
 		return true;

--- a/src/pocketmine/command/defaults/ListCommand.php
+++ b/src/pocketmine/command/defaults/ListCommand.php
@@ -54,7 +54,7 @@ class ListCommand extends VanillaCommand{
 		}
 		
 		$sender->sendMessage(new TranslationContainer("commands.players.list", [$onlineCount, $sender->getServer()->getMaxPlayers()]));
-		if(($sender instanceof ConsoleCommandSender) and ($onlineCount === 0){
+		if(($sender instanceof ConsoleCommandSender) and ($onlineCount === 0)){
 			return false;
 		}
 		$sender->sendMessage(substr($online, 0, -2));


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Removes the empty message sent to a console user if there are no players on the server.
![](http://i.imgur.com/qQXE8gL.png?raw=true)

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
Yes this is the best way to "fix" this and no it will not break things.
There is no real "problem" this removes one empty message (I'm one of the people who get annoyed with a messy console)
-->

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->
I have indeed tested this commit and it works.
<!-- Please review things below: -->

If the CommandSender is a ConsoleCommandSender and the online player count is 0 it will no longer write an empty message to the console.