### PR TITLE
Fix high load when teleporting and some teleportation weirdness

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2348,6 +2348,10 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 				break;
 			case ProtocolInfo::MOVE_PLAYER_PACKET:
+				if($this->teleportPosition !== null){
+					break;
+				}
+
 				if($this->linkedEntity instanceof Entity){
 					$entity = $this->linkedEntity;
 					if($entity instanceof Boat){
@@ -2368,8 +2372,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					$this->forceMovement = new Vector3($this->x, $this->y, $this->z);
 				}
 
-				if($this->teleportPosition !== null or ($this->forceMovement instanceof Vector3 and (($dist = $newPos->distanceSquared($this->forceMovement)) > 0.1 or $revert))){
-					if($this->forceMovement instanceof Vector3) $this->sendPosition($this->forceMovement, $packet->yaw, $packet->pitch);
+				if($this->forceMovement instanceof Vector3 and (($dist = $newPos->distanceSquared($this->forceMovement)) > 0.1 or $revert)){
+					$this->sendPosition($this->forceMovement, $packet->yaw, $packet->pitch);
 				}else{
 					$packet->yaw %= 360;
 					$packet->pitch %= 360;


### PR DESCRIPTION
### Description
Fix issues like #1889 where teleporting a player would cause a total server freeze.


### Reason to modify
I'm not 100% sure why this issue occurs, but the client seems to spam MovePlayer back to its original position when teleported due to chunks not being loaded, causing the server to think they are very rapidly moving backwards and forwards between two locations.

This pull request fixes the issue by ignoring all MovePlayer packets sent by the client when they are subjected to a teleport. This alters the teleportation behaviour slightly, as the client will appear not to move from their current location until chunks at their destination have been loaded.

### Tests & Reviews
This has been tested on a few servers and *appears* to fix the problem, however since I cannot reliably reproduce the bug it is hard to say for sure. Please test and review.
