### PR TITLE
Add unescaped slashes on json configs

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -188,7 +188,7 @@ class Config{
 						$content = $this->writeProperties();
 						break;
 					case Config::JSON:
-						$content = json_encode($this->config, JSON_PRETTY_PRINT | JSON_BIGINT_AS_STRING);
+						$content = json_encode($this->config, JSON_PRETTY_PRINT | JSON_BIGINT_AS_STRING | JSON_UNESCAPED_SLASHES);
 						break;
 					case Config::YAML:
 						$content = yaml_emit($this->config, YAML_UTF8_ENCODING);


### PR DESCRIPTION
### Description
Its for adding encryption on JSON configs.


### Reason to modify
- Think twice before modifying: is it the best way?

Yes
- will it break things?

no

### Tests & Reviews
<!-- Uncomment based on the situation -->
I have tested the code and it works.

<!-- Please review things below: -->

