### PR TITLE
Add sound on spawnLightning and sendLightning

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2456,7 +2456,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Player $p
 	 */
 	public function sendLighting(int $x, int $y, int $z, Player $p){
-		$this->addSound(new ExplodeSound(new Vector3($x,$y,$z)), $this->getPlayers());
+		$this->addSound(new ExplodeSound(new Vector3($x, $y, $z)), $this->getPlayers());
 		$pk = new AddEntityPacket();
 		$pk->type = Lightning::NETWORK_ID;
 		$pk->eid = mt_rand(10000000, 100000000);

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -113,6 +113,7 @@ use pocketmine\utils\MainLogger;
 use pocketmine\utils\Random;
 use pocketmine\utils\ReversePriorityQueue;
 use pocketmine\level\particle\Particle;
+use pocketmine\level\sound\ExplodeSound;
 use pocketmine\level\sound\BlockPlaceSound;
 use pocketmine\level\sound\Sound;
 use pocketmine\level\particle\DestroyBlockParticle;
@@ -2455,6 +2456,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Player $p
 	 */
 	public function sendLighting(int $x, int $y, int $z, Player $p){
+		$this->addSound(new ExplodeSound(new Vector3($x,$y,$z)), $this->getPlayers());
 		$pk = new AddEntityPacket();
 		$pk->type = Lightning::NETWORK_ID;
 		$pk->eid = mt_rand(10000000, 100000000);
@@ -2490,7 +2492,8 @@ class Level implements ChunkManager, Metadatable{
 		]);
 
 		$chunk = $this->getChunk($pos->x >> 4, $pos->z >> 4, false);
-
+		$this->addSound(new ExplodeSound($pos), $this->getPlayers());
+		
 		$lightning = new Lightning($chunk, $nbt);
 		$lightning->spawnToAll();
 


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
Add sound on spawnLightning and sendLightning
Implements Lightning Sound when Lightning has been called or spawned.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
For a while, we can use this and wait till we found the real of Lightning Sound from MCPE Client.
And, default Minecraft is has Lightning sound, so why not we try to add this?

### Tests & Reviews
<!-- Uncomment based on the situation -->
i've been tested it and it seem good
<!-- I have tested the code and it works. -->

<!-- Please review things below: -->

