### PR TITLE
Replaced NBT::putItemHelper() and NBT::getItemHelper() with new methods

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -989,7 +989,7 @@ class Item implements ItemIds, \JsonSerializable{
 	 * Serializes the item to an NBT CompoundTag
 	 *
 	 * @param int $slot optional, the inventory slot of the item
-     * @param string $tagName optional, the tag name
+	 * @param string $tagName optional, the tag name
 	 *
 	 * @return CompoundTag
 	 */

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -989,6 +989,7 @@ class Item implements ItemIds, \JsonSerializable{
 	 * Serializes the item to an NBT CompoundTag
 	 *
 	 * @param int $slot optional, the inventory slot of the item
+     * @param string $tagName optional, the tag name
 	 *
 	 * @return CompoundTag
 	 */

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1564,8 +1564,6 @@ class Level implements ChunkManager, Metadatable{
 	 */
 	public function dropItem(Vector3 $source, Item $item, Vector3 $motion = null, int $delay = 10){
 		$motion = $motion === null ? new Vector3(lcg_value() * 0.2 - 0.1, 0.2, lcg_value() * 0.2 - 0.1) : $motion;
-		$itemTag = $item->nbtSerialize();
-		$itemTag->setName("Item");
 
 		if($item->getId() > 0 and $item->getCount() > 0){
 			$itemEntity = Entity::createEntity("Item", $this->getChunk($source->getX() >> 4, $source->getZ() >> 4, true), new CompoundTag("", [
@@ -1585,7 +1583,7 @@ class Level implements ChunkManager, Metadatable{
 					new FloatTag("", 0)
 				]),
 				"Health" => new ShortTag("Health", 5),
-				"Item" => $itemTag,
+				"Item" => $item->nbtSerialize(-1, "Item"),
 				"PickupDelay" => new ShortTag("PickupDelay", $delay)
 			]));
 

--- a/src/pocketmine/tile/BrewingStand.php
+++ b/src/pocketmine/tile/BrewingStand.php
@@ -150,7 +150,7 @@ class BrewingStand extends Spawnable implements InventoryHolder, Container, Name
 		if($i < 0){
 			return Item::get(Item::AIR, 0, 0);
 		}else{
-			return NBT::getItemHelper($this->namedtag->Items[$i]);
+			return Item::nbtDeserialize($this->namedtag->Items[$i]);
 		}
 	}
 
@@ -165,8 +165,6 @@ class BrewingStand extends Spawnable implements InventoryHolder, Container, Name
 	public function setItem($index, Item $item){
 		$i = $this->getSlotIndex($index);
 
-		$d = NBT::putItemHelper($item, $index);
-
 		if($item->getId() === Item::AIR or $item->getCount() <= 0){
 			if($i >= 0){
 				unset($this->namedtag->Items[$i]);
@@ -177,9 +175,9 @@ class BrewingStand extends Spawnable implements InventoryHolder, Container, Name
 					break;
 				}
 			}
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}
 
 		return true;

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -126,8 +126,6 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	public function setItem($index, Item $item){
 		$i = $this->getSlotIndex($index);
 
-		$d = $item->nbtSerialize($index);
-
 		if($item->getId() === Item::AIR or $item->getCount() <= 0){
 			if($i >= 0){
 				unset($this->namedtag->Items[$i]);
@@ -138,9 +136,9 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 					break;
 				}
 			}
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}
 
 		return true;

--- a/src/pocketmine/tile/Dispenser.php
+++ b/src/pocketmine/tile/Dispenser.php
@@ -123,7 +123,7 @@ class Dispenser extends Spawnable implements InventoryHolder, Container, Nameabl
 		if($i < 0){
 			return Item::get(Item::AIR, 0, 0);
 		}else{
-			return NBT::getItemHelper($this->namedtag->Items[$i]);
+			return Item::nbtDeserialize($this->namedtag->Items[$i]);
 		}
 	}
 
@@ -138,8 +138,6 @@ class Dispenser extends Spawnable implements InventoryHolder, Container, Nameabl
 	public function setItem($index, Item $item){
 		$i = $this->getSlotIndex($index);
 
-		$d = NBT::putItemHelper($item, $index);
-
 		if($item->getId() === Item::AIR or $item->getCount() <= 0){
 			if($i >= 0){
 				unset($this->namedtag->Items[$i]);
@@ -150,9 +148,9 @@ class Dispenser extends Spawnable implements InventoryHolder, Container, Nameabl
 					break;
 				}
 			}
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}
 
 		return true;
@@ -347,9 +345,6 @@ class Dispenser extends Spawnable implements InventoryHolder, Container, Nameabl
 
 					break;
 				default:
-					$itemTag = NBT::putItemHelper($needItem);
-					$itemTag->setName("Item");
-
 					$nbt = new CompoundTag("", [
 						"Pos" => new ListTag("Pos", [
 							new DoubleTag("", $this->x + $motion[0] * 2 + 0.5),
@@ -366,7 +361,7 @@ class Dispenser extends Spawnable implements InventoryHolder, Container, Nameabl
 							new FloatTag("", 0)
 						]),
 						"Health" => new ShortTag("Health", 5),
-						"Item" => $itemTag,
+						"Item" => $needItem->nbtSerialize(-1, "Item"),
 						"PickupDelay" => new ShortTag("PickupDelay", 10)
 					]);
 

--- a/src/pocketmine/tile/Dropper.php
+++ b/src/pocketmine/tile/Dropper.php
@@ -118,7 +118,7 @@ class Dropper extends Spawnable implements InventoryHolder, Container, Nameable{
 		if($i < 0){
 			return Item::get(Item::AIR, 0, 0);
 		}else{
-			return NBT::getItemHelper($this->namedtag->Items[$i]);
+			return Item::nbtDeserialize($this->namedtag->Items[$i]);
 		}
 	}
 
@@ -133,8 +133,6 @@ class Dropper extends Spawnable implements InventoryHolder, Container, Nameable{
 	public function setItem($index, Item $item){
 		$i = $this->getSlotIndex($index);
 
-		$d = NBT::putItemHelper($item, $index);
-
 		if($item->getId() === Item::AIR or $item->getCount() <= 0){
 			if($i >= 0){
 				unset($this->namedtag->Items[$i]);
@@ -145,9 +143,9 @@ class Dropper extends Spawnable implements InventoryHolder, Container, Nameable{
 					break;
 				}
 			}
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}
 
 		return true;
@@ -235,10 +233,6 @@ class Dropper extends Spawnable implements InventoryHolder, Container, Nameable{
 					}
 			}
 
-			$itemTag = NBT::putItemHelper($needItem);
-			$itemTag->setName("Item");
-
-
 			$nbt = new CompoundTag("", [
 				"Pos" => new ListTag("Pos", [
 					new DoubleTag("", $this->x + $motion[0] * 2 + 0.5),
@@ -255,7 +249,7 @@ class Dropper extends Spawnable implements InventoryHolder, Container, Nameable{
 					new FloatTag("", 0)
 				]),
 				"Health" => new ShortTag("Health", 5),
-				"Item" => $itemTag,
+				"Item" => $needItem->nbtSerialize(-1, "Item"),
 				"PickupDelay" => new ShortTag("PickupDelay", 10)
 			]);
 

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -154,8 +154,6 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	public function setItem($index, Item $item){
 		$i = $this->getSlotIndex($index);
 
-		$d = $item->nbtSerialize($index);
-
 		if($item->getId() === Item::AIR or $item->getCount() <= 0){
 			if($i >= 0){
 				unset($this->namedtag->Items[$i]);
@@ -166,9 +164,9 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 					break;
 				}
 			}
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}
 
 		return true;

--- a/src/pocketmine/tile/Hopper.php
+++ b/src/pocketmine/tile/Hopper.php
@@ -198,7 +198,7 @@ class Hopper extends Spawnable implements InventoryHolder, Container, Nameable{
 		if($i < 0){
 			return Item::get(Item::AIR, 0, 0);
 		}else{
-			return NBT::getItemHelper($this->namedtag->Items[$i]);
+			return Item::nbtDeserialize($this->namedtag->Items[$i]);
 		}
 	}
 
@@ -213,8 +213,6 @@ class Hopper extends Spawnable implements InventoryHolder, Container, Nameable{
 	public function setItem($index, Item $item){
 		$i = $this->getSlotIndex($index);
 
-		$d = NBT::putItemHelper($item, $index);
-
 		if($item->getId() === Item::AIR or $item->getCount() <= 0){
 			if($i >= 0){
 				unset($this->namedtag->Items[$i]);
@@ -225,9 +223,9 @@ class Hopper extends Spawnable implements InventoryHolder, Container, Nameable{
 					break;
 				}
 			}
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i] = $item->nbtSerialize($index);
 		}
 
 		return true;

--- a/src/pocketmine/tile/ItemFrame.php
+++ b/src/pocketmine/tile/ItemFrame.php
@@ -34,8 +34,7 @@ class ItemFrame extends Spawnable{
 
 	public function __construct(FullChunk $chunk, CompoundTag $nbt){
 		if(!isset($nbt->Item)){
-			$nbt->Item = NBT::putItemHelper(Item::get(Item::AIR));
-			$nbt->Item->setName("Item");
+			$nbt->Item = Item::get(Item::AIR)->nbtSerialize(-1, "Item");
 		}
 
 		if(!isset($nbt->ItemRotation)){
@@ -63,13 +62,11 @@ class ItemFrame extends Spawnable{
 	}
 
 	public function getItem(){
-		return NBT::getItemHelper($this->namedtag->Item);
+		return Item::nbtDeserialize($this->namedtag->Item);
 	}
 
 	public function setItem(Item $item, bool $setChanged = true){
-		$nbtItem = NBT::putItemHelper($item);
-		$nbtItem->setName("Item");
-		$this->namedtag->Item = $nbtItem;
+		$this->namedtag->Item = $item->nbtSerialize(-1, "Item");
 		if($setChanged) {
 			$this->setChanged();
 		}


### PR DESCRIPTION
### Description
After commit fb001b7 NBT::putItemHelper() and NBT::getItemHelper() were removed, however there are still some classes wich use them, causing a crash


### Reason to modify
This pr fixes the issue descripted above by replacing NBT::putItemHelper() and NBT::getItemHelper() with respectively Item::nbtSerialize() and Item::nbtDeserialize()

### Tests & Reviews
I have tested the code and it works.