### PR TITLE
addEnchantment() returns the class.

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -588,8 +588,9 @@ class Item implements ItemIds, \JsonSerializable{
 				"lvl" => new ShortTag("lvl", $ench->getLevel())
 			]);
 		}
-
+		
 		$this->setNamedTag($tag);
+		return $this;
 	}
 
 	/**

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -588,7 +588,7 @@ class Item implements ItemIds, \JsonSerializable{
 				"lvl" => new ShortTag("lvl", $ench->getLevel())
 			]);
 		}
-		
+
 		$this->setNamedTag($tag);
 		return $this;
 	}


### PR DESCRIPTION
### Description
This pull request is to simply have the item return the class after adding an enchant
instead of returning void.


### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? It is the best possible way without breaking anything.
- Have you made sure that there is actually a problem before trying to fix it? Yes, I've been thinking about it returning void, and thought this would be a good change for API.
- Explain the logic behind your changes - WHY and HOW what you have done works: Not much is needed to explain why I did this, much less how I did it.
-->

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. --> Works splendid.

<!-- Please review things below: -->