### PR TITLE
Registered Wither Skeleton. Fixed #2272

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -73,6 +73,7 @@ use pocketmine\entity\ThrownExpBottle;
 use pocketmine\entity\ThrownPotion;
 use pocketmine\entity\Villager;
 use pocketmine\entity\Witch;
+use pocketmine\entity\WitherSkeleton;
 use pocketmine\entity\Wolf;
 use pocketmine\entity\XPOrb;
 use pocketmine\entity\Zombie;
@@ -2887,6 +2888,7 @@ class Server{
 		Entity::registerEntity(ThrownPotion::class);
 		Entity::registerEntity(Villager::class);
 		Entity::registerEntity(Witch::class);
+		Entity::registerEntity(WitherSkeleton::class);
 		Entity::registerEntity(Wolf::class);
 		Entity::registerEntity(XPOrb::class);
 		Entity::registerEntity(Zombie::class);

--- a/src/pocketmine/entity/WitherSkeleton.php
+++ b/src/pocketmine/entity/WitherSkeleton.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\entity;
+
+use pocketmine\network\protocol\AddEntityPacket;
+use pocketmine\Player;
+use pocketmine\network\protocol\MobEquipmentPacket;
+use pocketmine\item\Item as ItemItem;
+
+class WitherSkeleton extends Monster implements ProjectileSource{
+	const NETWORK_ID = 48;
+
+	public $dropExp = [5, 5];
+	
+	public function getName() : string{
+		return "Wither Skeleton";
+	}
+	
+	public function spawnTo(Player $player){
+		$pk = new AddEntityPacket();
+		$pk->eid = $this->getId();
+		$pk->type = WitherSkeleton::NETWORK_ID;
+		$pk->x = $this->x;
+		$pk->y = $this->y;
+		$pk->z = $this->z;
+		$pk->speedX = $this->motionX;
+		$pk->speedY = $this->motionY;
+		$pk->speedZ = $this->motionZ;
+		$pk->yaw = $this->yaw;
+		$pk->pitch = $this->pitch;
+		$pk->metadata = $this->dataProperties;
+		$player->dataPacket($pk);
+
+		parent::spawnTo($player);
+		
+		$pk = new MobEquipmentPacket();
+		$pk->eid = $this->getId();
+		$pk->item = new ItemItem(ItemItem::STONE_SWORD);
+		$pk->slot = 0;
+		$pk->selectedSlot = 0;
+
+		$player->dataPacket($pk);
+	}
+}


### PR DESCRIPTION
### Description
This pull request adds the missing 0.16 mob - Wither Skeleton. This pull request is also linked with the fix to issue #2272, where, when a wither skeleton is spawned externally, the console spams the said error.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
This is to prevent the future issues regarding basic mob implementation and to overcome #2272 the best way possible.

### Tests & Reviews
<!-- Uncomment based on the situation -->
Tested and...
![sx](https://cloud.githubusercontent.com/assets/18363310/21267629/33ca4c02-c3bc-11e6-85a0-174d4bdaf9f3.PNG)

<!-- I have tested the code and it works. -->

<!-- Please review things below: -->

Works. Tried adding nbts and etc. Tried spawning through various ways. It works flawlessly like it should.