### PR TITLE
Re-implement ItemFrameDropItemEvent, fix #2389

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -42,6 +42,7 @@ use pocketmine\entity\Minecart;
 use pocketmine\entity\Projectile;
 use pocketmine\entity\ThrownExpBottle;
 use pocketmine\entity\ThrownPotion;
+use pocketmine\event\block\ItemFrameDropItemEvent;
 use pocketmine\event\entity\EntityCombustByEntityEvent;
 use pocketmine\event\entity\EntityDamageByBlockEvent;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
@@ -3321,7 +3322,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 				$tile = $this->level->getTile($this->temporalVector->setComponents($packet->x, $packet->y, $packet->z));
 				if($tile instanceof ItemFrame){
-					if($this->isSpectator()){
+					$this->server->getPluginManager()->callEvent($ev = new ItemFrameDropItemEvent($this, $tile->getBlock(), $tile, $tile->getItem()));
+
+					if($this->isSpectator() or $ev->isCancelled()){
 						$tile->spawnTo($this);
 						break;
 					}

--- a/src/pocketmine/event/block/ItemFrameDropItemEvent.php
+++ b/src/pocketmine/event/block/ItemFrameDropItemEvent.php
@@ -34,7 +34,7 @@ class ItemFrameDropItemEvent extends BlockEvent implements Cancellable{
 	private $player;
 	/** @var  Item */
 	private $item;
-	/** @var  ItemFrame */
+	/** @var ItemFrame $itemFrame */
 	private $itemFrame;
 
 	public function __construct(Player $player, Block $block, ItemFrame $itemFrame, Item $item){


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
It was previously possible to control the behavior of item frame droppings through PlayerInteractEvent (<= v0.16). This PR fixes ItemFrameDropItemEvent not being triggered.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->
This will help developers extend the API to modify interactions with Item Frames. Cancellation of the event now prevents the item frame from dropping the item.

### Tests & Reviews
<!-- Uncomment based on the situation -->
I have tested the code and it works.

<!-- Please review things below: -->
